### PR TITLE
Compare numpy version strings using pkg_resources.parse_version

### DIFF
--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -844,7 +844,8 @@ class test_subprocess(TestCase):
 
 def print_versions():
     """Print the versions of software that numexpr relies on."""
-    if numpy.__version__ < minimum_numpy_version:
+    from pkg_resources import parse_version
+    if parse_version(numpy.__version__) < parse_version(minimum_numpy_version):
         print("*Warning*: NumPy version is lower than recommended: %s < %s" % \
               (numpy.__version__, minimum_numpy_version))
     print('-=' * 38)


### PR DESCRIPTION
When numpy hits version 1.10, string-based comparison of numpy version with minimum version will fail. Replacing with `pkg_resources.parse_version`.  I do not know if pkg_resources is available on all relevant versions. Others please verify.