### PR TITLE
Pass name and version to setuptools for pip (see #154)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,11 @@ with open('requirements.txt') as f:
     requirements = f.read().splitlines()
 
 # Fetch the version for numexpr (will be put in variable `version`)
-exec(open(os.path.join('numexpr', 'version.py')).read())
+with open(os.path.join('numexpr', 'version.py')) as f:
+    exec(f.read())
 
 def setup_package():
-    metadata = dict(  #name='numexpr',  # name already set in numpy.distutils
+    metadata = dict(  name='numexpr',
                       description='Fast numerical expression evaluator for NumPy',
                       version=version,
                       author='David M. Cooke, Francesc Alted and others',


### PR DESCRIPTION
If the name is also passed, it also gets installed correctly when calling
```
pip install .
```
in the source directory of numexpr. Otherwise, the message is:
```
Requirement already satisfied (use --upgrade to upgrade): numpy>=1.6 in /path/to/virtualenv/lib/python2.7/site-packages (from UNKNOWN==2.4.2.dev0)
Installing collected packages: UNKNOWN
  Found existing installation: UNKNOWN 0.0.0
    Can't uninstall 'UNKNOWN'. No files were found to uninstall.
  Running setup.py install for UNKNOWN
Successfully installed UNKNOWN-0.0.0
```