### PR TITLE
Support OMP_NUM_THREADS as fallback config variable

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -5,7 +5,8 @@
 Changes from 2.4.3 to 2.4.4
 ===========================
 
-#XXX version-specific blurb XXX#
+* Honor OMP_NUM_THREADS as a fallback in case NUMEXPR_NUM_THREADS is not
+  set. Fixes #161.
 
 Changes from 2.4.2 to 2.4.3
 ===========================

--- a/numexpr/__init__.py
+++ b/numexpr/__init__.py
@@ -42,25 +42,13 @@ from numexpr.necompiler import NumExpr, disassemble, evaluate
 from numexpr.tests import test, print_versions
 from numexpr.utils import (
     get_vml_version, set_vml_accuracy_mode, set_vml_num_threads,
-    set_num_threads, detect_number_of_cores)
+    set_num_threads, detect_number_of_cores, detect_number_of_threads)
 
 # Detect the number of cores
 ncores = detect_number_of_cores()
+nthreads = detect_number_of_threads()
 
 # Initialize the number of threads to be used
-# If this is modified, please update the note in:
-# https://github.com/pydata/numexpr/wiki/Numexpr-Users-Guide
-try:
-    nthreads = int(os.environ['NUMEXPR_NUM_THREADS'])
-except KeyError:
-    nthreads = ncores
-    # Check that we don't activate too many threads at the same time.
-    # 8 seems a sensible value.
-    if nthreads > 8:
-        nthreads = 8
-# Check that we don't surpass the MAX_THREADS in interpreter.cpp
-if nthreads > 4096:
-    nthreads = 4096
 if 'sparc' in platform.machine():
     import warnings
 

--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -13,6 +13,7 @@ import os
 import sys
 import platform
 import warnings
+from contextlib import contextmanager
 
 import numpy as np
 from numpy import (
@@ -813,6 +814,26 @@ class test_zerodim(TestCase):
         assert_array_equal(r1, a1)
 
 
+@contextmanager
+def _environment(key, value):
+    old = os.environ.get(key)
+    os.environ[key] = value
+    try:
+        yield
+    finally:
+        if old:
+            os.environ[key] = old
+        else:
+            del os.environ[key]
+
+
+# Test cases for the threading configuration
+class test_threading_config(TestCase):
+    def test_numexpr_num_threads(self):
+        with _environment('NUMEXPR_NUM_THREADS', '3'):
+            self.assertEquals(3, numexpr.detect_number_of_threads())
+
+
 # Case test for threads
 class test_threading(TestCase):
     def test_thread(self):
@@ -924,6 +945,7 @@ def suite():
         theSuite.addTest(
             unittest.makeSuite(test_irregular_stride))
         theSuite.addTest(unittest.makeSuite(test_zerodim))
+        theSuite.addTest(unittest.makeSuite(test_threading_config))
 
         # multiprocessing module is not supported on Hurd/kFreeBSD
         if (pl.system().lower() not in ('gnu', 'gnu/kfreebsd')):

--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -830,8 +830,12 @@ def _environment(key, value):
 # Test cases for the threading configuration
 class test_threading_config(TestCase):
     def test_numexpr_num_threads(self):
-        with _environment('NUMEXPR_NUM_THREADS', '3'):
+        with _environment('OMP_NUM_THREADS', '5'), _environment('NUMEXPR_NUM_THREADS', '3'):
             self.assertEquals(3, numexpr.detect_number_of_threads())
+
+    def test_omp_num_threads(self):
+        with _environment('OMP_NUM_THREADS', '5'):
+            self.assertEquals(5, numexpr.detect_number_of_threads())
 
 
 # Case test for threads

--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -830,8 +830,9 @@ def _environment(key, value):
 # Test cases for the threading configuration
 class test_threading_config(TestCase):
     def test_numexpr_num_threads(self):
-        with _environment('OMP_NUM_THREADS', '5'), _environment('NUMEXPR_NUM_THREADS', '3'):
-            self.assertEquals(3, numexpr.detect_number_of_threads())
+        with _environment('OMP_NUM_THREADS', '5'):
+            with _environment('NUMEXPR_NUM_THREADS', '3'):
+                self.assertEquals(3, numexpr.detect_number_of_threads())
 
     def test_omp_num_threads(self):
         with _environment('OMP_NUM_THREADS', '5'):

--- a/numexpr/utils.py
+++ b/numexpr/utils.py
@@ -122,7 +122,7 @@ def detect_number_of_threads():
     try:
         nthreads = int(os.environ['NUMEXPR_NUM_THREADS'])
     except KeyError:
-        nthreads = detect_number_of_cores()
+        nthreads = int(os.environ.get('OMP_NUM_THREADS', detect_number_of_cores()))
         # Check that we don't activate too many threads at the same time.
         # 8 seems a sensible value.
         if nthreads > 8:

--- a/numexpr/utils.py
+++ b/numexpr/utils.py
@@ -115,6 +115,24 @@ def detect_number_of_cores():
     return 1  # Default
 
 
+def detect_number_of_threads():
+    """
+    If this is modified, please update the note in: https://github.com/pydata/numexpr/wiki/Numexpr-Users-Guide
+    """
+    try:
+        nthreads = int(os.environ['NUMEXPR_NUM_THREADS'])
+    except KeyError:
+        nthreads = detect_number_of_cores()
+        # Check that we don't activate too many threads at the same time.
+        # 8 seems a sensible value.
+        if nthreads > 8:
+            nthreads = 8
+    # Check that we don't surpass the MAX_THREADS in interpreter.cpp
+    if nthreads > 4096:
+        nthreads = 4096
+    return nthreads
+
+
 class CacheDict(dict):
     """
     A dictionary that prevents itself from growing too much.


### PR DESCRIPTION
This fixes issue  #161.

Relevant changes:

* extracted thread count computation in order to make it testable
* introduce OMP_NUM_THREADS