### PR TITLE
Fix harmless data race.

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -18,3 +18,5 @@ Gaëtan de Menten contributed important bug fixes and speed
 enhancements.
 
 Antonio Valentino contributed the port to Python 3.
+
+Google Inc. contributed bug fixes.

--- a/numexpr/module.cpp
+++ b/numexpr/module.cpp
@@ -48,7 +48,10 @@ void *th_worker(void *tidptr)
 
     while (1) {
 
-        gs.init_sentinels_done = 0;     /* sentinels have to be initialised yet */
+        if (tid == 0) {
+            /* sentinels have to be initialised yet */
+            gs.init_sentinels_done = 0;
+        }
 
         /* Meeting point for all threads (wait for initialization) */
         pthread_mutex_lock(&gs.count_threads_mutex);


### PR DESCRIPTION
This would be fine on every processor I know, but is still a data race, and ThreadSanitizer reports it as such. Fix the concurrent write.
Also add "Google, Inc" to the authors file (sounds a bit ridiculous for such a small change, but is required by our policy for open source contributions).