### PR TITLE
Complex64

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -20,3 +20,7 @@ enhancements.
 Antonio Valentino contributed the port to Python 3.
 
 Google Inc. contributed bug fixes.
+
+S.J. Perkins and Robert A. McLeod added support for single-precision 
+complex64 dtype.
+

--- a/bench/timing_complex.py
+++ b/bench/timing_complex.py
@@ -1,0 +1,155 @@
+###################################################################
+#  Numexpr - Fast numerical array expression evaluator for NumPy.
+#
+#      License: MIT
+#      Author:  See AUTHORS.txt
+#
+#  See LICENSE.txt and LICENSES/*.txt for details about copyright and
+#  rights to use.
+####################################################################
+
+import timeit, numpy
+
+array_size = 1e6
+iterations = 2
+
+# Choose the type you want to benchmark
+#dtype = 'int8'
+#dtype = 'int16'
+#dtype = 'int32'
+#dtype = 'int64'
+#dtype = 'float32'
+#dtype = 'float64'
+dtype = 'complex64' 
+
+def compare_times(setup, expr):
+    print "Expression:", expr
+    namespace = {}
+    exec setup in namespace
+
+    numpy_timer = timeit.Timer(expr, setup)
+    numpy_time = numpy_timer.timeit(number=iterations)
+    print 'numpy:', numpy_time / iterations
+
+    try:
+        weave_timer = timeit.Timer('blitz("result=%s")' % expr, setup)
+        weave_time = weave_timer.timeit(number=iterations)
+        print "Weave:", weave_time/iterations
+
+        print "Speed-up of weave over numpy:", round(numpy_time/weave_time, 2)
+    except:
+        print "Skipping weave timing"
+
+    numexpr_timer = timeit.Timer('evaluate("%s", optimization="aggressive")' % expr, setup)
+    numexpr_time = numexpr_timer.timeit(number=iterations)
+    print "numexpr:", numexpr_time/iterations
+
+    tratio = numpy_time/numexpr_time
+    print "Speed-up of numexpr over numpy:", round(tratio, 2)
+    return tratio
+
+setup1 = """\
+from numpy import arange
+try: from scipy.weave import blitz
+except: pass
+from numexpr import evaluate
+result = arange(%f, dtype='%s')
+b = arange(%f, dtype='%s')
+c = arange(%f, dtype='%s')
+d = arange(%f, dtype='%s')
+e = arange(%f, dtype='%s')
+""" % ((array_size, dtype)*5)
+expr1 = 'b*c+d*e'
+
+setup2 = """\
+from numpy import arange
+try: from scipy.weave import blitz
+except: pass
+from numexpr import evaluate
+a = arange(%f, dtype='%s')
+b = arange(%f, dtype='%s')
+result = arange(%f, dtype='%s')
+""" % ((array_size, dtype)*3)
+expr2 = '2*a+3*b'
+
+
+setup3 = """\
+from numpy import arange, sin, cos, sinh
+try: from scipy.weave import blitz
+except: pass
+from numexpr import evaluate
+a = arange(2*%f, dtype='%s')[::2]
+b = arange(%f, dtype='%s')
+result = arange(%f, dtype='%s')
+""" % ((array_size, dtype)*3)
+expr3 = '2*a + (cos(3)+5)*sinh(cos(b))'
+
+
+setup4 = """\
+from numpy import arange, sin, cos, sinh, arctan2, arctan
+try: from scipy.weave import blitz
+except: pass
+from numexpr import evaluate
+a = arange(2*%f, dtype='%s')[::2]
+b = arange(%f, dtype='%s')
+result = arange(%f, dtype='%s')
+""" % ((array_size, dtype)*3)
+expr4 = '2*a + arctan(a/ b)'
+
+
+setup5 = """\
+from numpy import arange, sin, cos, sinh, arctan2, sqrt, where, arctan, complex64, complex128, conj
+try: from scipy.weave import blitz
+except: pass
+from numexpr import evaluate
+const = complex64( 0.1 + 0.1j )
+a = arange(2*%f, dtype='%s')[::2]
+b = arange(%f, dtype='%s')
+result = arange(%f, dtype='%s')
+""" % ((array_size, dtype)*3)
+
+# RAM: arctan2 isn't implemented for complex types
+# expr5 = 'where(0.1*a > arctan2(a, b), 2*a, arctan2(a,b))'
+# Nor do we have greater/less than for complex to boolean, added const above
+# expr5 = 'where(const*a > arctan(a/ b), 2*a, arctan(a/b))'
+expr5 = 'conj(a)*a'
+
+expr6 = 'where(a != 0.0, 2, b)'
+
+expr7 = 'where(a-10 != 0.0, a, 2)'
+
+expr8 = 'where(a==2, b+5, 2)'
+
+expr9 = 'sqrt(sin(a)**2 + cos(a)**2)'
+
+#expr8 = 'where(a%2 != 0.0, b+5, 2)'
+#expr9 = 'where(a%2 != 0.0, 2, b+5)'
+
+expr10 = 'a**2 + (b+1)**-2.5'
+
+expr11 = '(a+1)**50'
+
+expr12 = 'sqrt(a**2 + b**2)'
+
+def compare(check_only=False):
+    experiments = [(setup1, expr1), (setup2, expr2), (setup3, expr3),
+                   (setup4, expr4), (setup5, expr5), (setup5, expr6),
+                   (setup5, expr7), (setup5, expr8), (setup5, expr9),
+                   (setup5, expr10), (setup5, expr11), (setup5, expr12),
+                   ]
+    total = 0
+    for params in experiments:
+        total += compare_times(*params)
+        print
+    average = total / len(experiments)
+    print "Average =", round(average, 2)
+    return average
+
+if __name__ == '__main__':
+    import numexpr
+    numexpr.print_versions()
+
+    averages = []
+    for i in range(iterations):
+        averages.append(compare())
+    print "Averages:", ', '.join("%.2f" % x for x in averages)

--- a/numexpr/__init__.py
+++ b/numexpr/__init__.py
@@ -45,6 +45,7 @@ from numexpr.utils import (
     set_num_threads, detect_number_of_cores, detect_number_of_threads)
 
 # Detect the number of cores
+# RAM: the functions in util don't update numexpr.ncores or numexpr.nthreads, 
 ncores = detect_number_of_cores()
 nthreads = detect_number_of_threads()
 

--- a/numexpr/complex_functions.hpp
+++ b/numexpr/complex_functions.hpp
@@ -72,13 +72,6 @@ nc_conj(npy_cdouble *a, npy_cdouble *r)
 
 // Needed for allowing the internal casting in numexpr machinery for
 // conjugate operations
-inline float fconjf(float x)
-{
-    return x;
-}
-
-// Needed for allowing the internal casting in numexpr machinery for
-// conjugate operations
 inline double fconj(double x)
 {
     return x;

--- a/numexpr/complexf_functions.hpp
+++ b/numexpr/complexf_functions.hpp
@@ -1,0 +1,422 @@
+#ifndef NUMEXPR_COMPLEXF_FUNCTIONS_HPP
+#define NUMEXPR_COMPLEXF_FUNCTIONS_HPP
+
+/*********************************************************************
+  Numexpr - Fast numerical array expression evaluator for NumPy.
+
+      License: MIT
+      Author:  See AUTHORS.txt
+
+  See LICENSE.txt for details about copyright and rights to use.
+**********************************************************************/
+
+// TODO: Could just use std::complex<float> and std::complex<float>
+
+/* constants */
+static npy_cfloat nx_1 = {1., 0.};
+static npy_cfloat nx_half = {0.5, 0.};
+static npy_cfloat nx_i = {0., 1.};
+static npy_cfloat nx_i2 = {0., 0.5};
+/*
+static npy_cfloat nxf_mi = {0., -1.};
+static npy_cfloat nxf_pi2 = {M_PI/2., 0.};
+*/
+
+/* *************************** WARNING *****************************
+Due to the way Numexpr places the results of operations, the *x and *r
+pointers do point to the same address (apparently this doesn't happen
+in NumPy).  So, measures should be taken so as to not to reuse *x
+after the first *r has been overwritten.
+*********************************************************************
+*/
+
+static void
+nx_assign(npy_cfloat *x, npy_cfloat *r)
+{
+  r->real = x->real;
+  r->imag = x->imag;
+  return;
+}
+
+static void
+nx_sum(npy_cfloat *a, npy_cfloat *b, npy_cfloat *r)
+{
+    r->real = a->real + b->real;
+    r->imag = a->imag + b->imag;
+    return;
+}
+
+static void
+nx_diff(npy_cfloat *a, npy_cfloat *b, npy_cfloat *r)
+{
+    r->real = a->real - b->real;
+    r->imag = a->imag - b->imag;
+    return;
+}
+
+static void
+nx_neg(npy_cfloat *a, npy_cfloat *r)
+{
+    r->real = -a->real;
+    r->imag = -a->imag;
+    return;
+}
+
+static void
+nx_conj(npy_cfloat *a, npy_cfloat *r)
+{
+    r->real = a->real;
+    r->imag = -a->imag;
+    return;
+}
+
+// RAM: What this means is if the user calls conj(x) on a float or double do a 
+// null-op so the interpreter doesn't break.
+// Needed for allowing the internal casting in numexpr machinery for
+// conjugate operations
+inline float fconjf(float x)
+{
+    return x;
+}
+
+
+
+static void
+nx_prod(npy_cfloat *a, npy_cfloat *b, npy_cfloat *r)
+{
+    float ar=a->real, br=b->real, ai=a->imag, bi=b->imag;
+    r->real = ar*br - ai*bi;
+    r->imag = ar*bi + ai*br;
+    return;
+}
+
+static void
+nx_quot(npy_cfloat *a, npy_cfloat *b, npy_cfloat *r)
+{
+    float ar=a->real, br=b->real, ai=a->imag, bi=b->imag;
+    float d = br*br + bi*bi;
+    r->real = (ar*br + ai*bi)/d;
+    r->imag = (ai*br - ar*bi)/d;
+    return;
+}
+
+static void
+nx_sqrt(npy_cfloat *x, npy_cfloat *r)
+{
+    float s,d;
+    if (x->real == 0. && x->imag == 0.)
+        *r = *x;
+    else {
+        s = sqrtf((fabsf(x->real) + hypotf(x->real,x->imag))/2);
+        d = x->imag/(2*s);
+        if (x->real > 0.) {
+            r->real = s;
+            r->imag = d;
+        }
+        else if (x->imag >= 0.) {
+            r->real = d;
+            r->imag = s;
+        }
+        else {
+            r->real = -d;
+            r->imag = -s;
+        }
+    }
+    return;
+}
+
+static void
+nx_log(npy_cfloat *x, npy_cfloat *r)
+{
+    float l = hypotf(x->real,x->imag);
+    r->imag = atan2f(x->imag, x->real);
+    r->real = logf(l);
+    return;
+}
+
+static void
+nx_log1p(npy_cfloat *x, npy_cfloat *r)
+{
+    float l = hypotf(x->real + 1.0,x->imag);
+    r->imag = atan2f(x->imag, x->real + 1.0);
+    r->real = logf(l);
+    return;
+}
+
+static void
+nx_exp(npy_cfloat *x, npy_cfloat *r)
+{
+    float a = expf(x->real);
+    r->real = a*cosf(x->imag);
+    r->imag = a*sinf(x->imag);
+    return;
+}
+
+static void
+nx_expm1(npy_cfloat *x, npy_cfloat *r)
+{
+    float a = expf(x->real);
+    r->real = a*cosf(x->imag) - 1.0;
+    r->imag = a*sinf(x->imag);
+    return;
+}
+
+static void
+nx_pow(npy_cfloat *a, npy_cfloat *b, npy_cfloat *r)
+{
+    npy_intp n;
+    float ar=a->real, br=b->real, ai=a->imag, bi=b->imag;
+
+    if (br == 0. && bi == 0.) {
+        r->real = 1.;
+        r->imag = 0.;
+        return;
+    }
+    if (ar == 0. && ai == 0.) {
+        r->real = 0.;
+        r->imag = 0.;
+        return;
+    }
+    if (bi == 0 && (n=(npy_intp)br) == br) {
+        if (n > -100 && n < 100) {
+        npy_cfloat p, aa;
+        npy_intp mask = 1;
+        if (n < 0) n = -n;
+        aa = nx_1;
+        p.real = ar; p.imag = ai;
+        while (1) {
+            if (n & mask)
+                nx_prod(&aa,&p,&aa);
+            mask <<= 1;
+            if (n < mask || mask <= 0) break;
+            nx_prod(&p,&p,&p);
+        }
+        r->real = aa.real; r->imag = aa.imag;
+        if (br < 0) nx_quot(&nx_1, r, r);
+        return;
+        }
+    }
+    /* complexobject.c uses an inline version of this formula
+       investigate whether this had better performance or accuracy */
+    nx_log(a, r);
+    nx_prod(r, b, r);
+    nx_exp(r, r);
+    return;
+}
+
+
+static void
+nx_prodi(npy_cfloat *x, npy_cfloat *r)
+{
+    float xr = x->real;
+    r->real = -x->imag;
+    r->imag = xr;
+    return;
+}
+
+
+static void
+nx_acos(npy_cfloat *x, npy_cfloat *r)
+{
+    npy_cfloat a, *pa=&a;
+
+    nx_assign(x, pa);
+    nx_prod(x,x,r);
+    nx_diff(&nx_1, r, r);
+    nx_sqrt(r, r);
+    nx_prodi(r, r);
+    nx_sum(pa, r, r);
+    nx_log(r, r);
+    nx_prodi(r, r);
+    nx_neg(r, r);
+    return;
+    /* return ncf_neg(ncf_prodi(ncf_log(ncf_sum(x,ncf_prod(ncf_i,
+       ncf_sqrt(ncf_diff(ncf_1,ncf_prod(x,x))))))));
+    */
+}
+
+static void
+nx_acosh(npy_cfloat *x, npy_cfloat *r)
+{
+    npy_cfloat t, a, *pa=&a;
+
+    nx_assign(x, pa);
+    nx_sum(x, &nx_1, &t);
+    nx_sqrt(&t, &t);
+    nx_diff(x, &nx_1, r);
+    nx_sqrt(r, r);
+    nx_prod(&t, r, r);
+    nx_sum(pa, r, r);
+    nx_log(r, r);
+    return;
+    /*
+      return ncf_log(ncf_sum(x,
+      ncf_prod(ncf_sqrt(ncf_sum(x,ncf_1)), ncf_sqrt(ncf_diff(x,ncf_1)))));
+    */
+}
+
+static void
+nx_asin(npy_cfloat *x, npy_cfloat *r)
+{
+    npy_cfloat a, *pa=&a;
+    nx_prodi(x, pa);
+    nx_prod(x, x, r);
+    nx_diff(&nx_1, r, r);
+    nx_sqrt(r, r);
+    nx_sum(pa, r, r);
+    nx_log(r, r);
+    nx_prodi(r, r);
+    nx_neg(r, r);
+    return;
+    /*
+      return ncf_neg(ncf_prodi(ncf_log(ncf_sum(ncf_prod(ncf_i,x),
+      ncf_sqrt(ncf_diff(ncf_1,ncf_prod(x,x)))))));
+    */
+}
+
+
+static void
+nx_asinh(npy_cfloat *x, npy_cfloat *r)
+{
+    npy_cfloat a, *pa=&a;
+    nx_assign(x, pa);
+    nx_prod(x, x, r);
+    nx_sum(&nx_1, r, r);
+    nx_sqrt(r, r);
+    nx_sum(r, pa, r);
+    nx_log(r, r);
+    return;
+    /*
+      return ncf_log(ncf_sum(ncf_sqrt(ncf_sum(ncf_1,ncf_prod(x,x))),x));
+    */
+}
+
+static void
+nx_atan(npy_cfloat *x, npy_cfloat *r)
+{
+    npy_cfloat a, *pa=&a;
+    nx_diff(&nx_i, x, pa);
+    nx_sum(&nx_i, x, r);
+    nx_quot(r, pa, r);
+    nx_log(r,r);
+    nx_prod(&nx_i2, r, r);
+    return;
+    /*
+      return ncf_prod(ncf_i2,ncf_log(ncf_quot(ncf_sum(ncf_i,x),ncf_diff(ncf_i,x))));
+    */
+}
+
+static void
+nx_atanh(npy_cfloat *x, npy_cfloat *r)
+{
+    npy_cfloat a, b, *pa=&a, *pb=&b;
+    nx_assign(x, pa);
+    nx_diff(&nx_1, pa, r);
+    nx_sum(&nx_1, pa, pb);
+    nx_quot(pb, r, r);
+    nx_log(r, r);
+    nx_prod(&nx_half, r, r);
+    return;
+    /*
+      return ncf_prod(ncf_half,ncf_log(ncf_quot(ncf_sum(ncf_1,x),ncf_diff(ncf_1,x))));
+    */
+}
+
+static void
+nx_cos(npy_cfloat *x, npy_cfloat *r)
+{
+    float xr=x->real, xi=x->imag;
+    r->real = cosf(xr)*coshf(xi);
+    r->imag = -sinf(xr)*sinhf(xi);
+    return;
+}
+
+static void
+nx_cosh(npy_cfloat *x, npy_cfloat *r)
+{
+    float xr=x->real, xi=x->imag;
+    r->real = cosf(xi)*coshf(xr);
+    r->imag = sinf(xi)*sinhf(xr);
+    return;
+}
+
+
+#define M_LOG10_E 0.434294481903251827651128918916605082294397
+
+static void
+nx_log10(npy_cfloat *x, npy_cfloat *r)
+{
+    nx_log(x, r);
+    r->real *= M_LOG10_E;
+    r->imag *= M_LOG10_E;
+    return;
+}
+
+static void
+nx_sin(npy_cfloat *x, npy_cfloat *r)
+{
+    float xr=x->real, xi=x->imag;
+    r->real = sinf(xr)*coshf(xi);
+    r->imag = cosf(xr)*sinhf(xi);
+    return;
+}
+
+static void
+nx_sinh(npy_cfloat *x, npy_cfloat *r)
+{
+    float xr=x->real, xi=x->imag;
+    r->real = cosf(xi)*sinhf(xr);
+    r->imag = sinf(xi)*coshf(xr);
+    return;
+}
+
+static void
+nx_tan(npy_cfloat *x, npy_cfloat *r)
+{
+    float sr,cr,shi,chi;
+    float rs,is,rc,ic;
+    float d;
+    float xr=x->real, xi=x->imag;
+    sr = sinf(xr);
+    cr = cosf(xr);
+    shi = sinhf(xi);
+    chi = coshf(xi);
+    rs = sr*chi;
+    is = cr*shi;
+    rc = cr*chi;
+    ic = -sr*shi;
+    d = rc*rc + ic*ic;
+    r->real = (rs*rc+is*ic)/d;
+    r->imag = (is*rc-rs*ic)/d;
+    return;
+}
+
+static void
+nx_tanh(npy_cfloat *x, npy_cfloat *r)
+{
+    float si,ci,shr,chr;
+    float rs,is,rc,ic;
+    float d;
+    float xr=x->real, xi=x->imag;
+    si = sinf(xi);
+    ci = cosf(xi);
+    shr = sinhf(xr);
+    chr = coshf(xr);
+    rs = ci*shr;
+    is = si*chr;
+    rc = ci*chr;
+    ic = si*shr;
+    d = rc*rc + ic*ic;
+    r->real = (rs*rc+is*ic)/d;
+    r->imag = (is*rc-rs*ic)/d;
+    return;
+}
+
+static void
+nx_abs(npy_cfloat *x, npy_cfloat *r)
+{
+    r->real = sqrtf(x->real*x->real + x->imag*x->imag);
+    r->imag = 0;
+}
+
+#endif // NUMEXPR_COMPLEXF_FUNCTIONS_HPP

--- a/numexpr/functions.hpp
+++ b/numexpr/functions.hpp
@@ -8,6 +8,7 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
+
 /* These #if blocks make it easier to query this file, without having
    to define every row function before #including it. */
 #ifndef FUNC_FF
@@ -50,6 +51,47 @@ FUNC_FFF(FUNC_FFF_LAST,    NULL,          NULL,   NULL,    NULL)
 #ifdef ELIDE_FUNC_FFF
 #undef ELIDE_FUNC_FFF
 #undef FUNC_FFF
+#endif
+
+#ifndef FUNC_XX
+#define ELIDE_FUNC_XX
+#define FUNC_XX(...)
+#endif
+FUNC_XX(FUNC_SQRT_XX,    "sqrt_xx",     nx_sqrt, nx_sqrt, vcSqrt)
+FUNC_XX(FUNC_SIN_XX,     "sin_xx",      nx_sin,   vcSin)
+FUNC_XX(FUNC_COS_XX,     "cos_xx",      nx_cos,   vcCos)
+FUNC_XX(FUNC_TAN_XX,     "tan_xx",      nx_tan,   vcTan)
+FUNC_XX(FUNC_ARCSIN_XX,  "arcsin_xx",   nx_asin,  vcAsin)
+FUNC_XX(FUNC_ARXXOS_XX,  "arccos_xx",   nx_acos,  vcAcos)
+FUNC_XX(FUNC_ARCTAN_XX,  "arctan_xx",   nx_atan,  vcAtan)
+FUNC_XX(FUNC_SINH_XX,    "sinh_xx",     nx_sinh,  vcSinh)
+FUNC_XX(FUNC_COSH_XX,    "cosh_xx",     nx_cosh,  vcCosh)
+FUNC_XX(FUNC_TANH_XX,    "tanh_xx",     nx_tanh,  vcTanh)
+FUNC_XX(FUNC_ARCSINH_XX, "arcsinh_xx",  nx_asinh, vcAsinh)
+FUNC_XX(FUNC_ARXXOSH_XX, "arccosh_xx",  nx_acosh, vcAcosh)
+FUNC_XX(FUNC_ARCTANH_XX, "arctanh_xx",  nx_atanh, vcAtanh)
+FUNC_XX(FUNC_LOG_XX,     "log_xx",      nx_log,   vcLn)
+FUNC_XX(FUNC_LOG1P_XX,   "log1p_xx",    nx_log1p, vcLog1p)
+FUNC_XX(FUNC_LOG10_XX,   "log10_xx",    nx_log10, vcLog10)
+FUNC_XX(FUNC_EXP_XX,     "exp_xx",      nx_exp,   vcExp)
+FUNC_XX(FUNC_EXPM1_XX,   "expm1_xx",    nx_expm1, vcExpm1)
+FUNC_XX(FUNC_ABS_XX,     "absolute_xx", nx_abs,   vcAbs_)
+FUNC_XX(FUNC_CONJ_XX,    "conjugate_xx",nx_conj,  vcConj)
+FUNC_XX(FUNC_XX_LAST,    NULL,          NULL,     NULL)
+#ifdef ELIDE_FUNC_XX
+#undef ELIDE_FUNC_XX
+#undef FUNC_XX
+#endif
+
+#ifndef FUNC_XXX
+#define ELIDE_FUNC_XXX
+#define FUNC_XXX(...)
+#endif
+FUNC_XXX(FUNC_POW_XXX,   "pow_xxx", nx_pow)
+FUNC_XXX(FUNC_XXX_LAST,  NULL,      NULL)
+#ifdef ELIDE_FUNC_XXX
+#undef ELIDE_FUNC_XXX
+#undef FUNC_XXX
 #endif
 
 #ifndef FUNC_DD
@@ -134,3 +176,4 @@ FUNC_CCC(FUNC_CCC_LAST,  NULL,      NULL)
 #undef ELIDE_FUNC_CCC
 #undef FUNC_CCC
 #endif
+

--- a/numexpr/interp_body.cpp
+++ b/numexpr/interp_body.cpp
@@ -150,6 +150,8 @@
         #define d_reduce    *(double *)dest
         #define cr_reduce   *(double *)dest
         #define ci_reduce   *((double *)dest+1)
+        #define xr_reduce   *(float *)dest
+        #define xi_reduce   *((float *)dest+1)
 #else /* Reduce is the outer loop */
         #define i_reduce    i_dest
         #define l_reduce    l_dest
@@ -157,6 +159,8 @@
         #define d_reduce    d_dest
         #define cr_reduce   cr_dest
         #define ci_reduce   ci_dest
+        #define xr_reduce   xr_dest
+        #define xi_reduce   xi_dest
 #endif
         #define b_dest ((char *)dest)[j]
         #define i_dest ((int *)dest)[j]
@@ -165,6 +169,8 @@
         #define d_dest ((double *)dest)[j]
         #define cr_dest ((double *)dest)[2*j]
         #define ci_dest ((double *)dest)[2*j+1]
+        #define xr_dest ((float *)dest)[2*j]
+        #define xi_dest ((float *)dest)[2*j+1]
         #define s_dest ((char *)dest + j*memsteps[store_in])
         #define b1    ((char   *)(x1+j*sb1))[0]
         #define i1    ((int    *)(x1+j*sb1))[0]
@@ -173,6 +179,8 @@
         #define d1    ((double *)(x1+j*sb1))[0]
         #define c1r   ((double *)(x1+j*sb1))[0]
         #define c1i   ((double *)(x1+j*sb1))[1]
+        #define x1r   ((float *)(x1+j*sb1))[0]
+        #define x1i   ((float *)(x1+j*sb1))[1]
         #define s1    ((char   *)x1+j*sb1)
         #define b2    ((char   *)(x2+j*sb2))[0]
         #define i2    ((int    *)(x2+j*sb2))[0]
@@ -181,6 +189,8 @@
         #define d2    ((double *)(x2+j*sb2))[0]
         #define c2r   ((double *)(x2+j*sb2))[0]
         #define c2i   ((double *)(x2+j*sb2))[1]
+        #define x2r   ((float *)(x2+j*sb2))[0]
+        #define x2i   ((float *)(x2+j*sb2))[1]
         #define s2    ((char   *)x2+j*sb2)
         #define b3    ((char   *)(x3+j*sb3))[0]
         #define i3    ((int    *)(x3+j*sb3))[0]
@@ -189,10 +199,14 @@
         #define d3    ((double *)(x3+j*sb3))[0]
         #define c3r   ((double *)(x3+j*sb3))[0]
         #define c3i   ((double *)(x3+j*sb3))[1]
+        #define x3r   ((float *)(x3+j*sb3))[0]
+        #define x3i   ((float *)(x3+j*sb3))[1]
         #define s3    ((char   *)x3+j*sb3)
         /* Some temporaries */
         double da, db;
         npy_cdouble ca, cb;
+        float fa, fb;
+        npy_cfloat xa, xb;
 
         switch (op) {
 
@@ -208,6 +222,7 @@
         case OP_COPY_FF: VEC_ARG1(memcpy(&f_dest, s1, sizeof(float)));
         case OP_COPY_DD: VEC_ARG1(memcpy(&d_dest, s1, sizeof(double)));
         case OP_COPY_CC: VEC_ARG1(memcpy(&cr_dest, s1, sizeof(double)*2));
+        case OP_COPY_XX: VEC_ARG1(memcpy(&xr_dest, s1, sizeof(float)*2));
 
         /* Bool */
         case OP_INVERT_BB: VEC_ARG1(b_dest = !b1);
@@ -379,7 +394,7 @@
             VEC_ARG2(d_dest = functions_ddd[arg3](d1, d2));
 #endif
 
-        /* Complex */
+        /* Complex double */
         case OP_CAST_CI: VEC_ARG1(cr_dest = (double)(i1);
                                   ci_dest = 0);
         case OP_CAST_CL: VEC_ARG1(cr_dest = (double)(l1);
@@ -440,6 +455,70 @@
         case OP_COMPLEX_CDD: VEC_ARG2(cr_dest = d1;
                                       ci_dest = d2);
 
+        /* Complex float */
+        case OP_CAST_XI: VEC_ARG1(xr_dest = (float)(i1);
+                                  xi_dest = 0);
+        case OP_CAST_XL: VEC_ARG1(xr_dest = (float)(l1);
+                                  xi_dest = 0);
+        case OP_CAST_XF: VEC_ARG1(xr_dest = f1;
+                                  xi_dest = 0);
+        // RAM: this needs a downcast
+        case OP_CAST_XD: VEC_ARG1(xr_dest = (float)d1;
+                                  xi_dest = 0);
+        case OP_ONES_LIKE_XX: VEC_ARG0(xr_dest = 1;
+                                       xi_dest = 0);
+        case OP_NEG_XX: VEC_ARG1(xr_dest = -x1r;
+                                 xi_dest = -x1i);
+
+        case OP_ADD_XXX: VEC_ARG2(xr_dest = x1r + x2r;
+                                  xi_dest = x1i + x2i);
+        case OP_SUB_XXX: VEC_ARG2(xr_dest = x1r - x2r;
+                                  xi_dest = x1i - x2i);
+        case OP_MUL_XXX: VEC_ARG2(fa = x1r*x2r - x1i*x2i;
+                                  xi_dest = x1r*x2i + x1i*x2r;
+                                  xr_dest = fa);
+        case OP_DIV_XXX:
+#ifdef USE_VMLXXX /* VML complex division is slower */
+            VEC_ARG2_VML(vcDiv(BLOCK_SIZE, (const MKL_Complex8*)x1,
+                               (const MKL_Complex8*)x2, (MKL_Complex8*)dest));
+#else
+            VEC_ARG2(fa = x2r*x2r + x2i*x2i;
+                     fb = (x1r*x2r + x1i*x2i) / fa;
+                     xi_dest = (x1i*x2r - x1r*x2i) / fa;
+                     xr_dest = fb);
+#endif
+        case OP_EQ_BXX: VEC_ARG2(b_dest = (x1r == x2r && x1i == x2i));
+        case OP_NE_BXX: VEC_ARG2(b_dest = (x1r != x2r || x1i != x2i));
+
+        case OP_WHERE_XBXX: VEC_ARG3(xr_dest = b1 ? x2r : x3r;
+                                     xi_dest = b1 ? x2i : x3i);
+        
+        case OP_FUNC_XXN:
+#ifdef USE_VML
+            VEC_ARG1_VML(functions_xx_vml[arg2](BLOCK_SIZE,
+                                                (const MKL_Complex8*)x1,
+                                                (MKL_Complex8*)dest));
+#else
+            // RAM: Ok something in here is not right...
+            VEC_ARG1(xa.real = x1r;
+                     xa.imag = x1i;
+                     functions_xx[arg2](&xa, &xa);
+                     xr_dest = xa.real;
+                     xi_dest = xa.imag);
+#endif
+        case OP_FUNC_XXXN: VEC_ARG2(xa.real = x1r;
+                                    xa.imag = x1i;
+                                    xb.real = x2r;
+                                    xb.imag = x2i;
+                                    functions_xxx[arg3](&xa, &xb, &xa);
+                                    xr_dest = xa.real;
+                                    xi_dest = xa.imag);
+
+        case OP_REAL_FX: VEC_ARG1(f_dest = x1r);
+        case OP_IMAG_FX: VEC_ARG1(f_dest = x1i);
+        case OP_COMPLEX_XFF: VEC_ARG2(xr_dest = d1;
+                                      xi_dest = d2);
+
         /* Reductions */
         case OP_SUM_IIN: VEC_ARG1(i_reduce += i1);
         case OP_SUM_LLN: VEC_ARG1(l_reduce += l1);
@@ -447,6 +526,8 @@
         case OP_SUM_DDN: VEC_ARG1(d_reduce += d1);
         case OP_SUM_CCN: VEC_ARG1(cr_reduce += c1r;
                                   ci_reduce += c1i);
+        case OP_SUM_XXN: VEC_ARG1(xr_reduce += x1r;
+                                  xi_reduce += x1i);
 
         case OP_PROD_IIN: VEC_ARG1(i_reduce *= i1);
         case OP_PROD_LLN: VEC_ARG1(l_reduce *= l1);
@@ -455,6 +536,9 @@
         case OP_PROD_CCN: VEC_ARG1(da = cr_reduce*c1r - ci_reduce*c1i;
                                    ci_reduce = cr_reduce*c1i + ci_reduce*c1r;
                                    cr_reduce = da);
+        case OP_PROD_XXN: VEC_ARG1(fa = xr_reduce*x1r - xi_reduce*x1i;
+                                   xi_reduce = xr_reduce*x1i + xi_reduce*x1r;
+                                   xr_reduce = fa);
 
         default:
             *pc_error = pc;
@@ -481,6 +565,8 @@
 #undef d_reduce
 #undef cr_reduce
 #undef ci_reduce
+#undef xr_reduce
+#undef xi_reduce
 #undef b_dest
 #undef i_dest
 #undef l_dest
@@ -488,6 +574,8 @@
 #undef d_dest
 #undef cr_dest
 #undef ci_dest
+#undef xr_dest
+#undef xi_dest
 #undef s_dest
 #undef b1
 #undef i1
@@ -496,6 +584,8 @@
 #undef d1
 #undef c1r
 #undef c1i
+#undef x1r
+#undef x1i
 #undef s1
 #undef b2
 #undef i2
@@ -504,6 +594,8 @@
 #undef d2
 #undef c2r
 #undef c2i
+#undef x2r
+#undef x2i
 #undef s2
 #undef b3
 #undef i3
@@ -512,6 +604,8 @@
 #undef d3
 #undef c3r
 #undef c3i
+#undef x3r
+#undef x3i
 #undef s3
 }
 

--- a/numexpr/interpreter.hpp
+++ b/numexpr/interpreter.hpp
@@ -48,6 +48,19 @@ enum FuncCCCCodes {
 #undef FUNC_CCC
 };
 
+enum FuncXXCodes {
+#define FUNC_XX(fop, ...) fop,
+#include "functions.hpp"
+#undef FUNC_XX
+};
+
+enum FuncXXXCodes {
+#define FUNC_XXX(fop, ...) fop,
+#include "functions.hpp"
+#undef FUNC_XXX
+};
+
+
 struct vm_params {
     int prog_len;
     unsigned char *program;

--- a/numexpr/module.cpp
+++ b/numexpr/module.cpp
@@ -47,10 +47,9 @@ void *th_worker(void *tidptr)
     vector<char> out_buffer;
 
     while (1) {
-
-        if (tid == 0) {
-            /* sentinels have to be initialised yet */
-            gs.init_sentinels_done = 0;
+        
+        if (tid==0) {
+            gs.init_sentinels_done = 0;     /* sentinels have to be initialised yet */
         }
 
         /* Meeting point for all threads (wait for initialization) */
@@ -423,7 +422,11 @@ initinterpreter()
 #define FUNC_DDD(name, sname, ...) add_func(name, sname);
 #define FUNC_CC(name, sname, ...)  add_func(name, sname);
 #define FUNC_CCC(name, sname, ...) add_func(name, sname);
+#define FUNC_XX(name, sname, ...)  add_func(name, sname);
+#define FUNC_XXX(name, sname, ...) add_func(name, sname);
 #include "functions.hpp"
+#undef FUNC_XXX
+#undef FUNC_XX
 #undef FUNC_CCC
 #undef FUNC_CC
 #undef FUNC_DDD

--- a/numexpr/numexpr_object.cpp
+++ b/numexpr/numexpr_object.cpp
@@ -24,6 +24,7 @@ size_from_char(char c)
         case 'f': return sizeof(float);
         case 'd': return sizeof(double);
         case 'c': return 2*sizeof(double);
+        case 'x': return 2*sizeof(float);
         case 's': return 0;  /* strings are ok but size must be computed */
         default:
             PyErr_SetString(PyExc_TypeError, "signature value not in 'bilfdcs'");
@@ -108,13 +109,15 @@ NumExpr_init(NumExprObject *self, PyObject *args, PyObject *kwds)
 
     n_inputs = (int)PyBytes_Size(signature);
     n_temps = (int)PyBytes_Size(tempsig);
-
+    //PyRun_SimpleString( "print('DEBUG: Numexpr finit')" );
+	
     if (o_constants) {
         if (!PySequence_Check(o_constants) ) {
                 PyErr_SetString(PyExc_TypeError, "constants must be a sequence");
                 return -1;
         }
         n_constants = (int)PySequence_Length(o_constants);
+		
         if (!(constants = PyTuple_New(n_constants)))
             return -1;
         if (!(constsig = PyBytes_FromStringAndSize(NULL, n_constants))) {
@@ -169,6 +172,13 @@ NumExpr_init(NumExprObject *self, PyObject *args, PyObject *kwds)
                 itemsizes[i] = size_from_char('d');
                 continue;
             }
+            /* NumPy single precision complex number */
+            if (PyArray_IsScalar(o,CFloat)) {
+                PyBytes_AS_STRING(constsig)[i] = 'x';
+                itemsizes[i] = size_from_char('x');
+                continue;                
+            }
+            /* Python double precision complex number */
             if (PyComplex_Check(o)) {
                 PyBytes_AS_STRING(constsig)[i] = 'c';
                 itemsizes[i] = size_from_char('c');
@@ -179,7 +189,7 @@ NumExpr_init(NumExprObject *self, PyObject *args, PyObject *kwds)
                 itemsizes[i] = (int)PyBytes_GET_SIZE(o);
                 continue;
             }
-            PyErr_SetString(PyExc_TypeError, "constants must be of type bool/int/long/float/double/complex/bytes");
+            PyErr_SetString(PyExc_TypeError, "constants must be of type bool/int/long/float/double/complex/complex64/bytes");
             Py_DECREF(constsig);
             Py_DECREF(constants);
             PyMem_Del(itemsizes);
@@ -194,7 +204,7 @@ NumExpr_init(NumExprObject *self, PyObject *args, PyObject *kwds)
             return -1;
         }
     }
-
+    //PyRun_SimpleString( "print('DEBUG: At fullsig parse')" );	
     fullsig = PyBytes_FromFormat("%c%s%s%s", get_return_sig(program),
         PyBytes_AS_STRING(signature), PyBytes_AS_STRING(constsig),
         PyBytes_AS_STRING(tempsig));
@@ -278,6 +288,16 @@ NumExpr_init(NumExprObject *self, PyObject *args, PyObject *kwds)
             double value = PyFloat_AS_DOUBLE(PyTuple_GET_ITEM(constants, i));
             for (j = 0; j < BLOCK_SIZE1; j++) {
                 dmem[j] = value;
+            }
+        } else if (c == 'x') {
+            /* In this particular case the constant is in a NumPy scalar
+             and in a regular Python object */
+            float *fmem = (float*)mem[i+n_inputs+1];
+            npy_cfloat value = PyArrayScalar_VAL(PyTuple_GET_ITEM(constants, i),
+                                            CFloat);
+            for (j = 0; j < 2*BLOCK_SIZE1; j++) {
+                fmem[j] = value.real;
+                fmem[j+1] = value.imag;
             }
         } else if (c == 'c') {
             double *cmem = (double*)mem[i+n_inputs+1];

--- a/numexpr/opcodes.hpp
+++ b/numexpr/opcodes.hpp
@@ -12,7 +12,7 @@ OPCODE(n, enum_name, exported, return_type, arg1_type, arg2_type, arg3_type)
 
 `exported` is NULL if the opcode shouldn't exported by the Python module.
 
-Types are Tb, Ti, Tl, Tf, Td, Tc, Ts, Tn, and T0; these symbols should be
+Types are Tb, Ti, Tl, Tf, Td, Tc, Ts, Tx, Tn, and T0; these symbols should be
 #defined to whatever is needed. (T0 is the no-such-arg type.)
 
 */
@@ -139,30 +139,60 @@ OPCODE(100, OP_REAL_DC, "real_dc", Td, Tc, T0, T0)
 OPCODE(101, OP_IMAG_DC, "imag_dc", Td, Tc, T0, T0)
 OPCODE(102, OP_COMPLEX_CDD, "complex_cdd", Tc, Td, Td, T0)
 
-OPCODE(103, OP_COPY_SS, "copy_ss", Ts, Ts, T0, T0)
+// RAM should really have op-codes for gt_bxx, lt_bxx, and 
+// gt_bcc, lt_bcc
+OPCODE(103, OP_EQ_BXX, "eq_bxx", Tb, Tx, Tx, T0)
+OPCODE(104, OP_NE_BXX, "ne_bxx", Tb, Tx, Tx, T0)
 
-OPCODE(104, OP_WHERE_BBBB, "where_bbbb", Tb, Tb, Tb, Tb)
+OPCODE(105, OP_CAST_XI, "cast_xi", Tx, Ti, T0, T0)
+OPCODE(106, OP_CAST_XL, "cast_xl", Tx, Tl, T0, T0)
+OPCODE(107, OP_CAST_XF, "cast_xf", Tx, Tf, T0, T0)
+OPCODE(108, OP_CAST_XD, "cast_xd", Tx, Td, T0, T0)
+OPCODE(109, OP_ONES_LIKE_XX, "ones_like_xx", Tx, T0, T0, T0)
+OPCODE(110, OP_COPY_XX, "copy_xx", Tx, Tx, T0, T0)
+OPCODE(111, OP_NEG_XX, "neg_xx", Tx, Tx, T0, T0)
+OPCODE(112, OP_ADD_XXX, "add_xxx", Tx, Tx, Tx, T0)
+OPCODE(113, OP_SUB_XXX, "sub_xxx", Tx, Tx, Tx, T0)
+OPCODE(114, OP_MUL_XXX, "mul_xxx", Tx, Tx, Tx, T0)
+OPCODE(115, OP_DIV_XXX, "div_xxx", Tx, Tx, Tx, T0)
+OPCODE(116, OP_WHERE_XBXX, "where_xbxx", Tx, Tb, Tx, Tx)
+OPCODE(117, OP_FUNC_XXN, "func_xxn", Tx, Tx, Tn, T0)
+OPCODE(118, OP_FUNC_XXXN, "func_xxxn", Tx, Tx, Tx, Tn)
 
-OPCODE(105, OP_CONTAINS_BSS, "contains_bss", Tb, Ts, Ts, T0)
+OPCODE(119, OP_REAL_FX, "real_fx", Tf, Tx, T0, T0)
+OPCODE(120, OP_IMAG_FX, "imag_fx", Tf, Tx, T0, T0)
+OPCODE(121, OP_COMPLEX_XFF, "complex_xff", Tx, Td, Td, T0)
 
-OPCODE(106, OP_REDUCTION, NULL, T0, T0, T0, T0)
+OPCODE(122, OP_COPY_SS, "copy_ss", Ts, Ts, T0, T0)
+
+OPCODE(123, OP_WHERE_BBBB, "where_bbbb", Tb, Tb, Tb, Tb)
+
+OPCODE(124, OP_CONTAINS_BSS, "contains_bss", Tb, Ts, Ts, T0)
+
+OPCODE(125, OP_REDUCTION, NULL, T0, T0, T0, T0)
 
 /* Last argument in a reduction is the axis of the array the
    reduction should be applied along. */
 
-OPCODE(107, OP_SUM, NULL, T0, T0, T0, T0)
-OPCODE(108, OP_SUM_IIN, "sum_iin", Ti, Ti, Tn, T0)
-OPCODE(109, OP_SUM_LLN, "sum_lln", Tl, Tl, Tn, T0)
-OPCODE(110, OP_SUM_FFN, "sum_ffn", Tf, Tf, Tn, T0)
-OPCODE(111, OP_SUM_DDN, "sum_ddn", Td, Td, Tn, T0)
-OPCODE(112, OP_SUM_CCN, "sum_ccn", Tc, Tc, Tn, T0)
+OPCODE(126, OP_SUM, NULL, T0, T0, T0, T0)
+OPCODE(127, OP_SUM_IIN, "sum_iin", Ti, Ti, Tn, T0)
+OPCODE(128, OP_SUM_LLN, "sum_lln", Tl, Tl, Tn, T0)
+OPCODE(129, OP_SUM_FFN, "sum_ffn", Tf, Tf, Tn, T0)
+OPCODE(130, OP_SUM_DDN, "sum_ddn", Td, Td, Tn, T0)
+OPCODE(131, OP_SUM_CCN, "sum_ccn", Tc, Tc, Tn, T0)
+OPCODE(132, OP_SUM_XXN, "sum_xxn", Tx, Tx, Tn, T0)
 
-OPCODE(113, OP_PROD, NULL, T0, T0, T0, T0)
-OPCODE(114, OP_PROD_IIN, "prod_iin", Ti, Ti, Tn, T0)
-OPCODE(115, OP_PROD_LLN, "prod_lln", Tl, Tl, Tn, T0)
-OPCODE(116, OP_PROD_FFN, "prod_ffn", Tf, Tf, Tn, T0)
-OPCODE(117, OP_PROD_DDN, "prod_ddn", Td, Td, Tn, T0)
-OPCODE(118, OP_PROD_CCN, "prod_ccn", Tc, Tc, Tn, T0)
+OPCODE(133, OP_PROD, NULL, T0, T0, T0, T0)
+OPCODE(134, OP_PROD_IIN, "prod_iin", Ti, Ti, Tn, T0)
+OPCODE(135, OP_PROD_LLN, "prod_lln", Tl, Tl, Tn, T0)
+OPCODE(136, OP_PROD_FFN, "prod_ffn", Tf, Tf, Tn, T0)
+OPCODE(137, OP_PROD_DDN, "prod_ddn", Td, Td, Tn, T0)
+OPCODE(138, OP_PROD_CCN, "prod_ccn", Tc, Tc, Tn, T0)
+OPCODE(139, OP_PROD_XXN, "prod_xxn", Tx, Tx, Tn, T0)
+
+// RAM: we also need to add an opcode for complex64->complex128 casting
+// it's also asking for conjugate_xx?  How is this done for conjugate_cc?
+OPCODE(140, OP_CAST_XC, "cast_xc", Tx, Tc, T0, T0 )
 
 /* Should be the last opcode */
-OPCODE(119, OP_END, NULL, T0, T0, T0, T0)
+OPCODE(141, OP_END, NULL, T0, T0, T0, T0)

--- a/numexpr/str-two-way.hpp
+++ b/numexpr/str-two-way.hpp
@@ -30,7 +30,16 @@
 */
 
 #include <limits.h>
-
+/*
+  Python 2.7 (the only Python 2.x version supported as of now and until 2020)
+  is built on windows with Visual Studio 2008 C compiler. That dictates that
+  the compiler which must be used by authors of third party Python modules.
+  See https://mail.python.org/pipermail/distutils-sig/2014-September/024885.html
+  Unfortunately this version of Visual Studio doesn't claim to be C99 compatible
+  and in particular it lacks the stdint.h header. So we have to replace it with
+  a public domain version.
+  Visual Studio 2010 and later have stdint.h.
+*/
 #ifdef _MSC_VER <= 1500		
 #include "win32/stdint.h"		
 #else		

--- a/numexpr/str-two-way.hpp
+++ b/numexpr/str-two-way.hpp
@@ -31,22 +31,9 @@
 
 #include <limits.h>
 
-/*
-  Python 2.7 (the only Python 2.x version supported as of now and until 2020)
-  is built on windows with Visual Studio 2008 C compiler. That dictates that
-  the compiler which must be used by authors of third party Python modules.
-  See https://mail.python.org/pipermail/distutils-sig/2014-September/024885.html
-
-  Unfortunately this version of Visual Studio doesn't claim to be C99 compatible
-  and in particular it lacks the stdint.h header. So we have to replace it with
-  a public domain version.
-
-  Visual Studio 2010 and later have stdint.h.
-*/
-
-#ifdef _MSC_VER <= 1500
-#include "win32/stdint.h"
-#else
+#ifdef _MSC_VER <= 1500		
+#include "win32/stdint.h"		
+#else		
 #include <stdint.h>
 #endif
 

--- a/numexpr/tests/test_complex64_simple.py
+++ b/numexpr/tests/test_complex64_simple.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Jul 29 13:30:55 2015
+
+@author: rmcleod
+"""
+
+import numpy as np
+import numexpr as ne
+
+ne.set_num_threads(48)
+
+print( ne.nthreads )
+
+#### COMPLEX64 #####
+a = np.random.normal( size=[512,512] ).astype('float32')
+b = np.random.normal( size=[512,512] ).astype('float32')
+c = np.random.normal( size=[512,512] ).astype('float32')
+z = a + 1.0j*b
+y = b + 1.0j*c
+
+# print( "z.dtype = " + str(z.dtype) )
+
+test0 = ne.evaluate( "a + b" )
+print( "Float test0.dtype = " + str(test0.dtype) )
+
+test1 = ne.evaluate( "z*y + 3.0*z**2" )
+print( "Float test1.dtype = " + str(test1.dtype) )
+test2 = ne.evaluate( "3.0 + 3.0*z**2 - 50*z" )
+print( "Float test2.dtype = " + str(test2.dtype) )
+
+try:
+    test3 = ne.evaluate( "real(z)" )
+    print( "Float test3.dtype = " + str(test3.dtype) )
+except NotImplementedError, err:
+    print( err )
+
+try:
+    test4 = ne.evaluate( "conj(z)" )
+    print( "Float test4.dtype = " + str(test4.dtype) )
+except NotImplementedError, err:
+    print( err )
+    
+try:
+    test5 = ne.evaluate( "complex(a,b)" )
+    print( "Float test5.dtype = " + str(test5.dtype) )
+except (NotImplementedError, RuntimeError), err:
+    print( err )
+    
+#### COMPLEX128 #####
+ad = np.random.normal( size=[512,512] ).astype('float64')
+bd = np.random.normal( size=[512,512] ).astype('float64')
+cd = np.random.normal( size=[512,512] ).astype('float64')
+zd = ad + 1.0j*bd
+yd = bd + 1.0j*cd
+
+# print( "z.dtype = " + str(z.dtype) )
+test0d = ne.evaluate( "ad + bd" )
+print( "Double test0.dtype = " + str(test0d.dtype) )
+
+test1d = ne.evaluate( "zd*yd + 3.0*zd**2" )
+print( "Double test1.dtype = " + str(test1d.dtype) )
+test2d = ne.evaluate( "3.0 + 3.0*zd**2 - 50*zd" )
+print( "Double test2.dtype = " + str(test2d.dtype) )
+
+try:
+    test3d = ne.evaluate( "real(zd)" )
+    print( "Double test3.dtype = " + str(test3d.dtype) )
+except NotImplementedError, err:
+    print( err )
+
+try:
+    test4d = ne.evaluate( "conj(zd)" )
+    print( "Double test4.dtype = " + str(test4d.dtype) )
+except NotImplementedError, err:
+    print( err )
+    
+try:
+    test5d = ne.evaluate( "complex(ad,bd)" )
+    print( "Double test5.dtype = " + str(test5d.dtype) )
+except (NotImplementedError, RuntimeError), err:
+    print( err )

--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -334,7 +334,25 @@ class test_evaluate(TestCase):
         x = (a + 2 * b) / (1 + a + 4 * b * b)
         y = evaluate("(a + 2*b) / (1 + a + 4*b*b)")
         assert_array_almost_equal(x, y)
+		
+    def test_complex64_expr(self):
+        def complex64_func(a, b):
+            c = zeros(a.shape, dtype=complex64)
+            c.real = a
+            c.imag = b
+            return c
 
+        a = arange(1e4, dtype='float32' )
+        b = (arange(1e4) ** 1e-5).astype('float32')
+        z = ( a + 1j * b ).astype( 'complex64' ) # RAM this is complex128 by default numpy rules
+        x = z.imag
+        x = sin(complex64_func(a,b)).real + z.imag
+
+        # RAM: this check cannot pass because we don't have a function to do this 
+        # complex64(a,b) in the function list
+        y = evaluate("sin(complex64(a, b)).real + z.imag")
+        assert_array_almost_equal(x, y)
+		
     def test_complex_expr(self):
         def complex(a, b):
             c = zeros(a.shape, dtype=complex_)

--- a/numexpr/utils.py
+++ b/numexpr/utils.py
@@ -128,8 +128,8 @@ def detect_number_of_threads():
         # 8 seems a sensible value.
         max_sensible_threads = 8
         if nthreads > max_sensible_threads:	# RAM: add a warning
-            print( "NumExpr warning: threads being set to " + str(max_sensible_threads) /
-                + ", increase with util.set_num_threads(n)" )
+            print( "NumExpr warning: threads being set to " + str(max_sensible_threads) 
+				  + ", increase with util.set_num_threads(n)" )
             nthreads = max_sensible_threads		
     # Check that we don't surpass the MAX_THREADS in interpreter.cpp		
     if nthreads > 4096:		


### PR DESCRIPTION
Based from sjperkins/numexpr/compelx64 but starting with current master.

Changes from sjperkins changes:
1.) `sizeof` for `'x'` type was `2*double`
2.) `kind_rank` put `complex64` below `double`, changed this but it introduces other casting problems.
3.) no op-code for `cast_xc`, added at `op_code 140` for now.
4.) Re-wrote all `'x'` class functions to `nx_????` or similar.  This makes tracking problems much more transparent, rather than constant undesired up-casts to `complex128`.
5.) `getType()` did not differentiate between `complex64` and `complex128` with an `itemsize` check.
6.) `OP_COPY_XX` was copying `sizeof(double)*2`, which would have caused an overflow if called.
7.) Added `#defines` in macro `#define add_func` for `FUNC_XX` and `FUNC_XXX` in `module.cpp`
8.) Added `timing_complex.py` test script
9.) When `utils.set_num_threads()` is called it now updates `numexpr.nthreads`.

### Issues

Casting issues are rearing their head between the various float and complex types.  Currently in expressions.py correct behavior is set correctly for `float` and `complex64`, but this breaks some 
casting rules for `double` and `complex128` as a result.

I find issues with how the `dict functions{}` and `kind_rank` in `expressions.py` work.
Basically we don't differentiate between order (byte-count) and kind (integer, floating-point, complex).  This makes proper casting rules more or less impossible going forward.  

Currently expressions.functions is used to filter names in `necompiler.stringToExpression`.  If you 
look at the `functions` dict, (`expressions.py:354`), you'll see I have two blocks of code that gives 
proper behavior to `complex64`, or `complex128`, but not both at the same time.

The `kind_rank` is:

`kind_rank = ['bool', 'int', 'long', 'float', 'double', 'complex64', 'complex', 'none']`

The problem is that casting `complex64 <-> double` isn't actually what we want.  We can't 
put `double` behind `complex64` in the list either.

Therefore I think we need to move to a casting table, e.g.
```
u1  <   u2  <   u4  <   u8
^       ^       ^       ^
i1  <   i2  <   i4  <   i8
^       ^       ^       ^
                f4  <   f8  <   f16
                ^       ^
                c8  <   c16 <   c32
```

Another, perhaps parallel approach, is to let the user specify the return `dtype`.  This is probably best
handled by checking for `ne.evaluate( "...", out=... )` and either pulling the `dtype` from out if it is 
an `np.ndarray`, or let the user supply out as a `dtype` as well.  Then if the desired op isn't in the 
`opcode` or `funccode` list it will pop and error, but at least that gives control to the programmer.
