### PR TITLE
Fix bad #ifdef for including stdint on windows.

### DIFF
--- a/numexpr/str-two-way.hpp
+++ b/numexpr/str-two-way.hpp
@@ -44,7 +44,7 @@
   Visual Studio 2010 and later have stdint.h.
 */
 
-#ifdef _MSC_VER <= 1500
+#if _MSC_VER <= 1500
 #include "win32/stdint.h"
 #else
 #include <stdint.h>


### PR DESCRIPTION
This breaks newer compilers, because #ifdef was always defined, so win32/stdint was always being included, even on newer MSC versions.