### PR TITLE
Fix bad #ifdef for including stdint on windows. (again)

### DIFF
--- a/numexpr/str-two-way.hpp
+++ b/numexpr/str-two-way.hpp
@@ -44,7 +44,7 @@
   Visual Studio 2010 and later have stdint.h.
 */
 
-#if _MSC_VER <= 1500
+#if defined(_MSC_VER) && _MSC_VER <= 1500
 #include "win32/stdint.h"
 #else
 #include <stdint.h>


### PR DESCRIPTION
I think this one is less likely to break other platforms.  If Travis tests are passing, please just go ahead and close this PR.  Otherwise, this might fix things.

Sorry for not testing this better on the earlier PR - I'm doing testing/building only on Windows right now.