### PR TITLE
Fix Solaris issue with: numexpr/cpuinfo.py:53: UserWarning: [Errno 2]…

### DIFF
--- a/numexpr/cpuinfo.py
+++ b/numexpr/cpuinfo.py
@@ -507,11 +507,11 @@ class SunOSCPUInfo(CPUInfoBase):
             return
         info = command_info(arch='arch',
                             mach='mach',
-                            uname_i='uname_i',
+                            uname_i=['uname', '-i'],
                             isainfo_b=['isainfo', '-b'],
                             isainfo_n=['isainfo', '-n'],
         )
-        info['uname_X'] = key_value_from_command('uname -X', sep='=')
+        info['uname_X'] = key_value_from_command(['uname', '-X'], sep='=')
         for line in command_by_line(['psrinfo', '-v', '0']):
             m = re.match(r'\s*The (?P<p>[\w\d]+) processor operates at', line)
             if m:


### PR DESCRIPTION
This fixes the problems I had with warnings from cpuinfo.py giving the:
```
UserWarning: [Errno 2]… No such file or directory
  stacklevel=stacklevel + 1)
```
errors.

Simply changing the way a couple of commands are called - both are instances of uname.