### PR TITLE
replace 1e5 (float) with 100000 (int)

### DIFF
--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -93,7 +93,7 @@ class test_numexpr(TestCase):
                       (b'add_ddd', b't3', b't3', b'c2[2.0]'),
                       (b'prod_ddn', b'r0', b't3', 2)])
         # Check that full reductions work.
-        x = zeros(1e5) + .01  # checks issue #41
+        x = zeros(100000) + .01  # checks issue #41
         assert_allclose(evaluate("sum(x+2,axis=None)"), sum(x + 2, axis=None))
         assert_allclose(evaluate("sum(x+2,axis=0)"), sum(x + 2, axis=0))
         assert_allclose(evaluate("prod(x,axis=0)"), prod(x, axis=0))


### PR DESCRIPTION
With recent numpy versions, using a float for the size argument will raise a TypeError.

This was causing the following two errors:
```
======================================================================
ERROR: test_reductions (numexpr.tests.test_numexpr.test_numexpr)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/numexpr-2.4.7.dev0-py2.7-linux-x86_64.egg/numexpr/tests/test_numexpr.py", line 96, in test_reductions
    x = zeros(1e5) + .01  # checks issue #41
TypeError: 'float' object cannot be interpreted as an index

======================================================================
ERROR: test_reductions (numexpr.tests.test_numexpr.test_numexpr2)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/numexpr-2.4.7.dev0-py2.7-linux-x86_64.egg/numexpr/tests/test_numexpr.py", line 96, in test_reductions
    x = zeros(1e5) + .01  # checks issue #41
TypeError: 'float' object cannot be interpreted as an index

----------------------------------------------------------------------
Ran 5436 tests in 5.804s

FAILED (errors=2)
```