### PR TITLE
[WIP]: Add min and max reduction functions

### DIFF
--- a/numexpr/expressions.py
+++ b/numexpr/expressions.py
@@ -231,22 +231,15 @@ def encode_axis(axis):
     return RawNode(axis)
 
 
-def sum_func(a, axis=None):
-    axis = encode_axis(axis)
-    if isinstance(a, ConstantNode):
-        return a
-    if isinstance(a, (bool, int_, long_, float, double, complex)):
-        a = ConstantNode(a)
-    return FuncNode('sum', [a, axis], kind=a.astKind)
-
-
-def prod_func(a, axis=None):
-    axis = encode_axis(axis)
-    if isinstance(a, (bool, int_, long_, float, double, complex)):
-        a = ConstantNode(a)
-    if isinstance(a, ConstantNode):
-        return a
-    return FuncNode('prod', [a, axis], kind=a.astKind)
+def gen_reduce_axis_func(name):
+    def _func(a, axis=None):
+        axis = encode_axis(axis)
+        if isinstance(a, ConstantNode):
+            return a
+        if isinstance(a, (bool, int_, long_, float, double, complex)):
+            a = ConstantNode(a)
+        return FuncNode(name, [a, axis], kind=a.astKind)
+    return _func
 
 
 @ophelper
@@ -373,8 +366,10 @@ functions = {
     'complex': func(complex, 'complex'),
     'conj': func(numpy.conj, 'complex'),
 
-    'sum': sum_func,
-    'prod': prod_func,
+    'sum': gen_reduce_axis_func('sum'),
+    'prod': gen_reduce_axis_func('prod'),
+    'min': gen_reduce_axis_func('min'),
+    'max': gen_reduce_axis_func('max'),
     'contains': contains_func,
 }
 

--- a/numexpr/interp_body.cpp
+++ b/numexpr/interp_body.cpp
@@ -456,6 +456,16 @@
                                    ci_reduce = cr_reduce*c1i + ci_reduce*c1r;
                                    cr_reduce = da);
 
+        case OP_MIN_IIN: VEC_ARG1(i_reduce = fmin(i_reduce, i1));
+        case OP_MIN_LLN: VEC_ARG1(l_reduce = fmin(l_reduce, l1));
+        case OP_MIN_FFN: VEC_ARG1(f_reduce = fmin(f_reduce, f1));
+        case OP_MIN_DDN: VEC_ARG1(d_reduce = fmin(d_reduce, d1));
+
+        case OP_MAX_IIN: VEC_ARG1(i_reduce = fmax(i_reduce, i1));
+        case OP_MAX_LLN: VEC_ARG1(l_reduce = fmax(l_reduce, l1));
+        case OP_MAX_FFN: VEC_ARG1(f_reduce = fmax(f_reduce, f1));
+        case OP_MAX_DDN: VEC_ARG1(d_reduce = fmax(d_reduce, d1));
+
         default:
             *pc_error = pc;
             return -3;

--- a/numexpr/interpreter.cpp
+++ b/numexpr/interpreter.cpp
@@ -45,7 +45,12 @@
 #define DEBUG_TEST 0
 #endif
 
-
+#ifndef INFINITY
+#define INFINITY (DBL_MAX+DBL_MAX)
+#endif
+#ifndef NAN
+#define NAN (INFINITY-INFINITY)
+#endif
 
 using namespace std;
 

--- a/numexpr/interpreter.cpp
+++ b/numexpr/interpreter.cpp
@@ -1362,16 +1362,26 @@ NumExpr_run(NumExprObject *self, PyObject *args, PyObject *kwds)
     /* Initialize the output to the reduction unit */
     if (is_reduction) {
         PyArrayObject *a = NpyIter_GetOperandArray(iter)[0];
-        if (last_opcode(self->program) >= OP_SUM &&
-            last_opcode(self->program) < OP_PROD) {
-                PyObject *zero = PyLong_FromLong(0);
-                PyArray_FillWithScalar(a, zero);
-                Py_DECREF(zero);
+        PyObject *fill;
+        int op = last_opcode(self->program);
+        if (op < OP_PROD) {
+            /* sum identity is 0 */
+            fill = PyLong_FromLong(0);
+        } else if (op >= OP_PROD && op < OP_MIN) {
+            /* product identity is 1 */
+            fill = PyLong_FromLong(1);
+        } else if (PyArray_DESCR(a)->kind == 'f') {
+            /* floating point min/max identity is NaN */
+            fill = PyFloat_FromDouble(NAN);
+        } else if (op >= OP_MIN && op < OP_MAX) {
+            /* integer min identity */
+            fill = PyLong_FromLong(LONG_MAX);
         } else {
-                PyObject *one = PyLong_FromLong(1);
-                PyArray_FillWithScalar(a, one);
-                Py_DECREF(one);
+            /* integer max identity */
+            fill = PyLong_FromLong(LONG_MIN);
         }
+        PyArray_FillWithScalar(a, fill);
+        Py_DECREF(fill);
     }
 
     /* Get the sizes of all the operands */

--- a/numexpr/necompiler.py
+++ b/numexpr/necompiler.py
@@ -261,7 +261,8 @@ def stringToExpression(s, types, context):
 
 
 def isReduction(ast):
-    return ast.value.startswith(b'sum_') or ast.value.startswith(b'prod_')
+    prefixes = (b'sum_', b'prod_', b'min_', b'max_')
+    return any(ast.value.startswith(p) for p in prefixes)
 
 
 def getInputOrder(ast, input_order=None):

--- a/numexpr/opcodes.hpp
+++ b/numexpr/opcodes.hpp
@@ -150,19 +150,30 @@ OPCODE(106, OP_REDUCTION, NULL, T0, T0, T0, T0)
 /* Last argument in a reduction is the axis of the array the
    reduction should be applied along. */
 
-OPCODE(107, OP_SUM, NULL, T0, T0, T0, T0)
-OPCODE(108, OP_SUM_IIN, "sum_iin", Ti, Ti, Tn, T0)
-OPCODE(109, OP_SUM_LLN, "sum_lln", Tl, Tl, Tn, T0)
-OPCODE(110, OP_SUM_FFN, "sum_ffn", Tf, Tf, Tn, T0)
-OPCODE(111, OP_SUM_DDN, "sum_ddn", Td, Td, Tn, T0)
-OPCODE(112, OP_SUM_CCN, "sum_ccn", Tc, Tc, Tn, T0)
+OPCODE(107, OP_SUM_IIN, "sum_iin", Ti, Ti, Tn, T0)
+OPCODE(108, OP_SUM_LLN, "sum_lln", Tl, Tl, Tn, T0)
+OPCODE(109, OP_SUM_FFN, "sum_ffn", Tf, Tf, Tn, T0)
+OPCODE(110, OP_SUM_DDN, "sum_ddn", Td, Td, Tn, T0)
+OPCODE(111, OP_SUM_CCN, "sum_ccn", Tc, Tc, Tn, T0)
 
-OPCODE(113, OP_PROD, NULL, T0, T0, T0, T0)
-OPCODE(114, OP_PROD_IIN, "prod_iin", Ti, Ti, Tn, T0)
-OPCODE(115, OP_PROD_LLN, "prod_lln", Tl, Tl, Tn, T0)
-OPCODE(116, OP_PROD_FFN, "prod_ffn", Tf, Tf, Tn, T0)
-OPCODE(117, OP_PROD_DDN, "prod_ddn", Td, Td, Tn, T0)
-OPCODE(118, OP_PROD_CCN, "prod_ccn", Tc, Tc, Tn, T0)
+OPCODE(112, OP_PROD, NULL, T0, T0, T0, T0)
+OPCODE(113, OP_PROD_IIN, "prod_iin", Ti, Ti, Tn, T0)
+OPCODE(114, OP_PROD_LLN, "prod_lln", Tl, Tl, Tn, T0)
+OPCODE(115, OP_PROD_FFN, "prod_ffn", Tf, Tf, Tn, T0)
+OPCODE(116, OP_PROD_DDN, "prod_ddn", Td, Td, Tn, T0)
+OPCODE(117, OP_PROD_CCN, "prod_ccn", Tc, Tc, Tn, T0)
+
+OPCODE(118, OP_MIN, NULL, T0, T0, T0, T0)
+OPCODE(119, OP_MIN_IIN, "min_iin", Ti, Ti, Tn, T0)
+OPCODE(120, OP_MIN_LLN, "min_lln", Tl, Tl, Tn, T0)
+OPCODE(121, OP_MIN_FFN, "min_ffn", Tf, Tf, Tn, T0)
+OPCODE(122, OP_MIN_DDN, "min_ddn", Td, Td, Tn, T0)
+
+OPCODE(123, OP_MAX, NULL, T0, T0, T0, T0)
+OPCODE(124, OP_MAX_IIN, "max_iin", Ti, Ti, Tn, T0)
+OPCODE(125, OP_MAX_LLN, "max_lln", Tl, Tl, Tn, T0)
+OPCODE(126, OP_MAX_FFN, "max_ffn", Tf, Tf, Tn, T0)
+OPCODE(127, OP_MAX_DDN, "max_ddn", Td, Td, Tn, T0)
 
 /* Should be the last opcode */
-OPCODE(119, OP_END, NULL, T0, T0, T0, T0)
+OPCODE(128, OP_END, NULL, T0, T0, T0, T0)

--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -97,17 +97,25 @@ class test_numexpr(TestCase):
         assert_allclose(evaluate("sum(x+2,axis=None)"), sum(x + 2, axis=None))
         assert_allclose(evaluate("sum(x+2,axis=0)"), sum(x + 2, axis=0))
         assert_allclose(evaluate("prod(x,axis=0)"), prod(x, axis=0))
+        assert_allclose(evaluate("min(x)"), np.min(x))
+        assert_allclose(evaluate("max(x,axis=0)"), np.max(x, axis=0))
 
         x = arange(10.0)
         assert_allclose(evaluate("sum(x**2+2,axis=0)"), sum(x ** 2 + 2, axis=0))
         assert_allclose(evaluate("prod(x**2+2,axis=0)"), prod(x ** 2 + 2, axis=0))
+        assert_allclose(evaluate("min(x**2+2,axis=0)"), np.min(x ** 2 + 2, axis=0))
+        assert_allclose(evaluate("max(x**2+2,axis=0)"), np.max(x ** 2 + 2, axis=0))
 
         x = arange(100.0)
         assert_allclose(evaluate("sum(x**2+2,axis=0)"), sum(x ** 2 + 2, axis=0))
         assert_allclose(evaluate("prod(x-1,axis=0)"), prod(x - 1, axis=0))
+        assert_allclose(evaluate("min(x-1,axis=0)"), np.min(x - 1, axis=0))
+        assert_allclose(evaluate("max(x-1,axis=0)"), np.max(x - 1, axis=0))
         x = linspace(0.1, 1.0, 2000)
         assert_allclose(evaluate("sum(x**2+2,axis=0)"), sum(x ** 2 + 2, axis=0))
         assert_allclose(evaluate("prod(x-1,axis=0)"), prod(x - 1, axis=0))
+        assert_allclose(evaluate("min(x-1,axis=0)"), np.min(x - 1, axis=0))
+        assert_allclose(evaluate("max(x-1,axis=0)"), np.max(x - 1, axis=0))
 
         # Check that reductions along an axis work
         y = arange(9.0).reshape(3, 3)
@@ -117,15 +125,25 @@ class test_numexpr(TestCase):
         assert_allclose(evaluate("prod(y**2, axis=1)"), prod(y ** 2, axis=1))
         assert_allclose(evaluate("prod(y**2, axis=0)"), prod(y ** 2, axis=0))
         assert_allclose(evaluate("prod(y**2, axis=None)"), prod(y ** 2, axis=None))
+        assert_allclose(evaluate("min(y**2, axis=1)"), np.min(y ** 2, axis=1))
+        assert_allclose(evaluate("min(y**2, axis=0)"), np.min(y ** 2, axis=0))
+        assert_allclose(evaluate("min(y**2, axis=None)"), np.min(y ** 2, axis=None))
+        assert_allclose(evaluate("max(y**2, axis=1)"), np.max(y ** 2, axis=1))
+        assert_allclose(evaluate("max(y**2, axis=0)"), np.max(y ** 2, axis=0))
+        assert_allclose(evaluate("max(y**2, axis=None)"), np.max(y ** 2, axis=None))
         # Check integers
         x = arange(10.)
         x = x.astype(int)
         assert_allclose(evaluate("sum(x**2+2,axis=0)"), sum(x ** 2 + 2, axis=0))
         assert_allclose(evaluate("prod(x**2+2,axis=0)"), prod(x ** 2 + 2, axis=0))
+        assert_allclose(evaluate("min(x**2+2,axis=0)"), np.min(x ** 2 + 2, axis=0))
+        assert_allclose(evaluate("max(x**2+2,axis=0)"), np.max(x ** 2 + 2, axis=0))
         # Check longs
         x = x.astype(long)
         assert_allclose(evaluate("sum(x**2+2,axis=0)"), sum(x ** 2 + 2, axis=0))
         assert_allclose(evaluate("prod(x**2+2,axis=0)"), prod(x ** 2 + 2, axis=0))
+        assert_allclose(evaluate("min(x**2+2,axis=0)"), np.min(x ** 2 + 2, axis=0))
+        assert_allclose(evaluate("max(x**2+2,axis=0)"), np.max(x ** 2 + 2, axis=0))
         # Check complex
         x = x + .1j
         assert_allclose(evaluate("sum(x**2+2,axis=0)"), sum(x ** 2 + 2, axis=0))


### PR DESCRIPTION
This PR adds two new reduction functions, `min` and `max`, which act like the numpy functions of the same name.

A few notes:
 * Neither function supports complex numbers for now, but this could be added if necessary.
 * I had to do some limbo to correctly initialize the output array, as there's no true identity value for min/max reductions. As of now, floating point min/max starts from NaN, while integer min/max starts from LONG_MAX/LONG_MIN, respectively.
 * Other parts of the code assume that opcodes can be converted into single ASCII character (0-127), which puts a hard limit on the number of total opcodes. I did some shuffling to make the new opcodes fit, but any additional opcodes will require a bigger restructuring.

Finally, I've tagged this as a work in progress because I haven't done any testing on non-Linux platforms.