### PR TITLE
Fix crash when evaluate() called from multiple threads

### DIFF
--- a/numexpr/module.cpp
+++ b/numexpr/module.cpp
@@ -187,6 +187,7 @@ int init_threads(void)
 
     /* Initialize mutex and condition variable objects */
     pthread_mutex_init(&gs.count_mutex, NULL);
+    pthread_mutex_init(&gs.parallel_mutex, NULL);
 
     /* Barrier initialization */
     pthread_mutex_init(&gs.count_threads_mutex, NULL);

--- a/numexpr/module.hpp
+++ b/numexpr/module.hpp
@@ -27,11 +27,14 @@ struct global_state {
     int force_serial;                /* force serial code instead of parallel? */
     int pid;                         /* the PID for this process */
 
-    /* Syncronization variables */
+    /* Synchronization variables for threadpool state */
     pthread_mutex_t count_mutex;
     int count_threads;
     pthread_mutex_t count_threads_mutex;
     pthread_cond_t count_threads_cv;
+
+    /* Mutual exclusion for access to global thread params (th_params) */
+    pthread_mutex_t parallel_mutex;
 
     global_state() {
         nthreads = 1;

--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -841,6 +841,7 @@ class test_threading_config(TestCase):
 
 # Case test for threads
 class test_threading(TestCase):
+
     def test_thread(self):
         import threading
 
@@ -851,6 +852,25 @@ class test_threading(TestCase):
 
         test = ThreadTest()
         test.start()
+        test.join()
+
+    def test_multithread(self):
+        import threading
+
+        # Running evaluate() from multiple threads shouldn't crash
+        def work(n):
+            a = arange(n)
+            evaluate('a+a')
+
+        work(10)  # warm compilation cache
+
+        nthreads = 30
+        threads = [threading.Thread(target=work, args=(1e5,))
+                   for i in range(nthreads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
 
 
 # The worker function for the subprocess (needs to be here because Windows


### PR DESCRIPTION
The attached unit test crashes quite reliably otherwise.
This change fixes the following crash in Pandas: https://stackoverflow.com/questions/25782912/pandas-and-numpy-thread-safety
