### PR TITLE
cpuinfo.py: Bring back printing CPU info on command line

### DIFF
--- a/numexpr/cpuinfo.py
+++ b/numexpr/cpuinfo.py
@@ -38,7 +38,7 @@ def getoutput(cmd, successful_status=(0,), stacklevel=1):
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
         output, _ = p.communicate()
         status = p.returncode
-    except EnvironmentError, e:
+    except EnvironmentError as e:
         warnings.warn(str(e), UserWarning, stacklevel=stacklevel)
         return False, ''
     if os.WIFEXITED(status) and os.WEXITSTATUS(status) in successful_status:
@@ -99,7 +99,7 @@ class CPUInfoBase(object):
                     return lambda func=self._try_call, attr=attr: func(attr)
             else:
                 return lambda: None
-        raise AttributeError, name
+        raise AttributeError(name)
 
     def _getNCPUs(self):
         return 1
@@ -128,7 +128,7 @@ class LinuxCPUInfo(CPUInfoBase):
             info[0]['uname_m'] = output.strip()
         try:
             fo = open('/proc/cpuinfo')
-        except EnvironmentError, e:
+        except EnvironmentError as e:
             warnings.warn(str(e), UserWarning)
         else:
             for line in fo:
@@ -600,12 +600,16 @@ class Win32CPUInfo(CPUInfoBase):
     # mean?
 
     def __init__(self):
+        try:
+            import _winreg
+        except ImportError:  # Python 3
+            import winreg as _winreg
+
         if self.info is not None:
             return
         info = []
         try:
             #XXX: Bad style to use so long `try:...except:...`. Fix it!
-            import _winreg
 
             prgx = re.compile(r"family\s+(?P<FML>\d+)\s+model\s+(?P<MDL>\d+)" \
                               "\s+stepping\s+(?P<STP>\d+)", re.IGNORECASE)
@@ -636,7 +640,7 @@ class Win32CPUInfo(CPUInfoBase):
                                     info[-1]["Model"] = int(srch.group("MDL"))
                                     info[-1]["Stepping"] = int(srch.group("STP"))
         except:
-            print sys.exc_value, '(ignoring)'
+            print(sys.exc_value, '(ignoring)')
         self.__class__.info = info
 
     def _not_impl(self):
@@ -804,4 +808,4 @@ if __name__ == "__main__":
                     info.append('%s=%s' % (name[1:], r))
                 else:
                     info.append(name[1:])
-    print 'CPU information: ' + ' '.join(info)
+    print('CPU information: ' + ' '.join(info))

--- a/numexpr/cpuinfo.py
+++ b/numexpr/cpuinfo.py
@@ -4,9 +4,7 @@
 #  cpuinfo - Get information about CPU
 #
 #      License: BSD
-#      Author:  Pearu Peterson <pearu@cens.ioc.ee>
-#
-#  See LICENSES/cpuinfo.txt for details about copyright and
+#      Author:  Pearu Peterson <pearu@cens.ioc.ee>pr
 #  rights to use.
 ####################################################################
 
@@ -636,8 +634,7 @@ class Win32CPUInfo(CPUInfoBase):
                                     info[-1]["Model"] = int(srch.group("MDL"))
                                     info[-1]["Stepping"] = int(srch.group("STP"))
         except:
-            print
-            sys.exc_value, '(ignoring)'
+            print sys.exc_value, '(ignoring)'
         self.__class__.info = info
 
     def _not_impl(self):

--- a/numexpr/cpuinfo.py
+++ b/numexpr/cpuinfo.py
@@ -796,16 +796,13 @@ if __name__ == "__main__":
     cpu.is_Intel()
     cpu.is_Alpha()
 
-    print
-    'CPU information:',
+    info = []
     for name in dir(cpuinfo):
         if name[0] == '_' and name[1] != '_':
             r = getattr(cpu, name[1:])()
             if r:
                 if r != 1:
-                    print
-                    '%s=%s' % (name[1:], r),
+                    info.append('%s=%s' % (name[1:], r))
                 else:
-                    print
-                    name[1:],
-    print
+                    info.append(name[1:])
+    print 'CPU information: ' + ' '.join(info)

--- a/numexpr/cpuinfo.py
+++ b/numexpr/cpuinfo.py
@@ -4,7 +4,9 @@
 #  cpuinfo - Get information about CPU
 #
 #      License: BSD
-#      Author:  Pearu Peterson <pearu@cens.ioc.ee>pr
+#      Author:  Pearu Peterson <pearu@cens.ioc.ee>
+#
+#  See LICENSES/cpuinfo.txt for details about copyright and
 #  rights to use.
 ####################################################################
 


### PR DESCRIPTION
Tested this on Windows with Python 2.7 and 3.5.
```
>python cpuinfo.py
CPU information: CPUInfoBase__get_nbits=32 getNCPUs=2 has_mmx is_32bit is_Intel is_i686

>py -3 cpuinfo.py
CPU information: CPUInfoBase__get_nbits=32 getNCPUs=2 has_mmx is_32bit is_Intel is_i686
```

```
> python -c "import cpuinfo, pprint; pprint.pprint(cpuinfo.cpu.info[0])"
{'Component Information': '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00',
 'Configuration Data': '\xff\xff\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00',
 'Family': 6,
 'FeatureSet': 2687451135L,
 'Identifier': u'x86 Family 6 Model 23 Stepping 10',
 'Model': 23,
 'Platform ID': 128,
 'Previous Update Signature': '\x00\x00\x00\x00\x0c\n\x00\x00',
 'Processor': '0',
 'ProcessorNameString': u'Intel(R) Core(TM)2 Duo CPU     P8600  @ 2.40GHz',
 'Stepping': 10,
 'Update Signature': '\x00\x00\x00\x00\x0c\n\x00\x00',
 'Update Status': 2,
 'VendorIdentifier': u'GenuineIntel',
 '~MHz': 2394}
```