### PR TITLE
Add unittest for strides over columns of numpy.rec.arrays

### DIFF
--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -380,6 +380,16 @@ class test_evaluate(TestCase):
         assert_array_equal(evaluate("c1"), c1)
         assert_array_equal(evaluate("a0+c1"), a0 + c1)
 
+    def test_recarray_strides(self):
+        a = arange(100)
+        b = arange(100,200)
+        recarr = np.rec.array(None, formats='f4,f4', shape=(100,))
+        recarr['f0'] = a
+        recarr['f1'] = b
+        c = recarr['f1']
+        assert_array_almost_equal(evaluate("sqrt(c) > 1."), sqrt(c) > 1.)
+        assert_array_almost_equal(evaluate("log10(c)"), log10(c))
+
     def test_broadcasting(self):
         a = arange(100).reshape(10, 10)[::2]
         c = arange(10)


### PR DESCRIPTION
This PR adds a unittest for strides over columns of numpy.rec.arrays
(issue #210)

This unittest currently fails when using Intel MKL (VML): When using VML in numexpr "strides" are not respected. Arrays are assumed to be continuous when using VML, which is not the case when using columns of numpy.rec.array (as pytables does).

This might be fixed by unpacking the strided array into a temporary buffer that is continuous. But there might be an easier fix?

Output of unittest:
```
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
Numexpr version:   2.5.1.dev0
NumPy version:     1.10.4
Python version:    2.7.11 |Anaconda 2.5.0 (64-bit)| (default, Dec  6 2015, 18:08:32)
[GCC 4.4.7 20120313 (Red Hat 4.4.7-1)]
Platform:          linux2-x86_64
AMD/Intel CPU?     True
VML available?     True
VML/MKL version:   Intel(R) Math Kernel Library Version 11.3.1 Product Build 20151021 for Intel(R) 64 architecture applications
Number of threads used by default: 2 (out of 2 detected cores)
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
..........F.......
======================================================================
FAIL: test_recarray_strides (__main__.test_evaluate)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "numexpr/tests/test_numexpr.py", line 391, in test_recarray_strides
    assert_array_almost_equal(evaluate("log10(c)"), log10(c))
[...]
AssertionError:
Arrays are not almost equal to 6 decimals

(mismatch 99.0%)
 x: array([ 2.      ,  0.      ,  2.004321,  0.30103 ,  2.0086  ,  0.477121,
        2.012837,  0.60206 ,  2.017033,  0.69897 ,  2.021189,  0.778151,
        2.025306,  0.845098,  2.029384,  0.90309 ,  2.033424,  0.954243,...
 y: array([ 2.      ,  2.004321,  2.0086  ,  2.012837,  2.017033,  2.021189,
        2.025306,  2.029384,  2.033424,  2.037426,  2.041393,  2.045323,
        2.049218,  2.053078,  2.056905,  2.060698,  2.064458,  2.068186,...

----------------------------------------------------------------------
Ran 18 tests in 0.790s

FAILED (failures=1)
```
It is easy to see that the output is wrong because the strides are not adhered to when using VML: 
The output should be log10(200, 201, 202...) = 2.xxx, 2.xx, 2.xx (array y)
But log10(0, 1, 2, 3) = 0, 0.30103, 0.47712 is "intermixed" because of the stride problem
