### PR TITLE
change abs() from 'abs' to 'absolute' in necompiler.vmlfunctions

### DIFF
--- a/numexpr/necompiler.py
+++ b/numexpr/necompiler.py
@@ -59,8 +59,8 @@ vml_functions = [
     "log10",
     "exp",
     "expm1",
-    "abs",
-    "conj",
+    "absolute",
+    "conjugate",
     "arctan2",
     "fmod",
     ]

--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -421,6 +421,16 @@ class test_evaluate(TestCase):
         else:
             self.fail()
 
+    def test_ex_uses_vml(self):
+        vml_funcs = [ "sin", "cos", "tan", "arcsin", "arccos", "arctan",
+                      "sinh", "cosh", "tanh", "arcsinh", "arccosh", "arctanh",
+                      "log", "log1p","log10", "exp", "expm1", "abs", "conj",
+                      "arctan2", "fmod"]
+        for func in vml_funcs:
+            strexpr = func+'(a)'
+            _, ex_uses_vml = numexpr.necompiler.getExprNames(strexpr, {})
+            assert_equal(ex_uses_vml, True, strexpr)
+
     if 'sparc' not in platform.machine():
         # Execution order set here so as to not use too many threads
         # during the rest of the execution.  See #33 for details.


### PR DESCRIPTION
In  ```necompiler.vml_functions``` the function ```abs()``` is defined as 'abs' while the parser uses numpy.absolute.

Testcase (this returns False on current master)
```python
import numexpr
from numexpr.necompiler import stringToExpression, getExprNames


def get_ex_uses_vml(expression):
    mysig = [('f1', float)]
    typemap = {'f1': float}
    strexpr = stringToExpression(expression, typemap, {})
    context = {}
    names, ex_uses_vml = getExprNames(expression, context)
    return ex_uses_vml

if __name__ == '__main__':
    print "numexpr version: ", numexpr.__version__
    print "VML: ", numexpr.get_vml_version()

    expression = 'abs(f1)'
    print expression, get_ex_uses_vml(expression)
```
