### PR TITLE
Fix shields in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,9 +11,11 @@ Numexpr: Fast numerical expression evaluator for NumPy
 
 .. |travis| image:: https://travis-ci.org/pydata/numexpr.png?branch=master
         :target: https://travis-ci.org/pydata/numexpr
-.. |appveyor| image:: https://ci.appveyor.com/api/projects/status/github/FrancescAlted/numexpr
-        :target: https://ci.appveyor.com/project/FrancescAlted/numexpr
-.. |pypi| image:: https://pypip.in/d/numexpr/badge.png
+.. |appveyor| image:: https://ci.appveyor.com/api/projects/status/github/pydata/numexpr
+        :target: https://ci.appveyor.com/project/pydata/numexpr
+.. |pypi| image:: https://img.shields.io/pypi/dm/numexpr.png
+        :target: https://pypi.python.org/pypi/numexpr
+.. |version| image:: https://img.shields.io/pypi/v/numexpr.png
         :target: https://pypi.python.org/pypi/numexpr
 
 


### PR DESCRIPTION
Update appveyor link to pydata org.
Use shields.io instead of pypip.in (more reliable).

pypip.in is offline, it might come back and other have started new servers to replace it, but their reliability is unknown. https://github.com/badges/pypipins/issues/37