### PR TITLE
type(kind_rank): list --> tuple

### DIFF
--- a/numexpr/expressions.py
+++ b/numexpr/expressions.py
@@ -32,7 +32,7 @@ type_to_kind = {bool: 'bool', int_: 'int', long_: 'long', float: 'float',
                 double: 'double', complex: 'complex', bytes: 'bytes'}
 kind_to_type = {'bool': bool, 'int': int_, 'long': long_, 'float': float,
                 'double': double, 'complex': complex, 'bytes': bytes}
-kind_rank = ['bool', 'int', 'long', 'float', 'double', 'complex', 'none']
+kind_rank = ('bool', 'int', 'long', 'float', 'double', 'complex', 'none')
 scalar_constant_types = [bool, int_, long, float, double, complex, bytes]
 
 # Final corrections for Python 3 (mainly for PyTables needs)


### PR DESCRIPTION
It is logical for kind_rank to be a tuple since it's not intended to be modifiable.