### PR TITLE
BUG: Eliminated warning about numexpr/tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -151,6 +151,7 @@ def setup_package():
             if 'library_dirs' in mkl_config_data:
                 library_dirs = ':'.join(mkl_config_data['library_dirs'])
             config.add_extension('interpreter', **extension_config_data)
+            config.set_options(quiet=True)
 
             config.make_config_py()
             config.add_subpackage('tests', 'numexpr/tests')


### PR DESCRIPTION
Because numexpr/tests was being added as a subpackage without setup.py
there were the following two warnings while building the package

```
Warning: Assuming default configuration (numexpr/tests/{setup_tests,setup}.py was not found) 
         Appending numexpr.tests configuration to numexpr

Ignoring attempt to set 'name' (from 'numexpr' to 'numexpr.tests')
```

The fix was to replace `config.add_subpackage('tests', 'numexpr/tests')`
with `config.add_data_dir('numexpr/tests')` akin how numpy itself adds test
directories in its setup.py