### PR TITLE
Fix pow result casting

### DIFF
--- a/numexpr/interp_body.cpp
+++ b/numexpr/interp_body.cpp
@@ -271,7 +271,7 @@
         case OP_SUB_LLL: VEC_ARG2(l_dest = l1 - l2);
         case OP_MUL_LLL: VEC_ARG2(l_dest = l1 * l2);
         case OP_DIV_LLL: VEC_ARG2(l_dest = l2 ? (l1 / l2) : 0);
-        case OP_POW_LLL: VEC_ARG2(l_dest = (l2 < 0) ? (1 / l1) : (long long)pow((long double)l1, (long double)l2));
+        case OP_POW_LLL: VEC_ARG2(l_dest = (l2 < 0) ? (1 / l1) : (long long)llround(pow((long double)l1, (long double)l2)));
         case OP_MOD_LLL: VEC_ARG2(l_dest = l2 ? (l1 % l2) : 0);
         case OP_LSHIFT_LLL: VEC_ARG2(l_dest = l1 << l2);
         case OP_RSHIFT_LLL: VEC_ARG2(l_dest = l1 >> l2);

--- a/numexpr/interp_body.cpp
+++ b/numexpr/interp_body.cpp
@@ -271,7 +271,11 @@
         case OP_SUB_LLL: VEC_ARG2(l_dest = l1 - l2);
         case OP_MUL_LLL: VEC_ARG2(l_dest = l1 * l2);
         case OP_DIV_LLL: VEC_ARG2(l_dest = l2 ? (l1 / l2) : 0);
+#if defined _MSC_VER && _MSC_VER < 1800
+        case OP_POW_LLL: VEC_ARG2(l_dest = (l2 < 0) ? (1 / l1) : (long long)pow((long double)l1, (long double)l2));
+#else
         case OP_POW_LLL: VEC_ARG2(l_dest = (l2 < 0) ? (1 / l1) : (long long)llround(pow((long double)l1, (long double)l2)));
+#endif
         case OP_MOD_LLL: VEC_ARG2(l_dest = l2 ? (l1 % l2) : 0);
         case OP_LSHIFT_LLL: VEC_ARG2(l_dest = l1 << l2);
         case OP_RSHIFT_LLL: VEC_ARG2(l_dest = l1 >> l2);

--- a/numexpr/interp_body.cpp
+++ b/numexpr/interp_body.cpp
@@ -271,7 +271,11 @@
         case OP_SUB_LLL: VEC_ARG2(l_dest = l1 - l2);
         case OP_MUL_LLL: VEC_ARG2(l_dest = l1 * l2);
         case OP_DIV_LLL: VEC_ARG2(l_dest = l2 ? (l1 / l2) : 0);
+#if _MSC_VER <= 1500
+        case OP_POW_LLL: VEC_ARG2(l_dest = (l2 < 0) ? (1 / l1) : (long long)pow((long double)l1, (long double)l2));
+#else
         case OP_POW_LLL: VEC_ARG2(l_dest = (l2 < 0) ? (1 / l1) : (long long)llround(pow((long double)l1, (long double)l2)));
+#endif
         case OP_MOD_LLL: VEC_ARG2(l_dest = l2 ? (l1 % l2) : 0);
         case OP_LSHIFT_LLL: VEC_ARG2(l_dest = l1 << l2);
         case OP_RSHIFT_LLL: VEC_ARG2(l_dest = l1 >> l2);

--- a/numexpr/interp_body.cpp
+++ b/numexpr/interp_body.cpp
@@ -271,11 +271,7 @@
         case OP_SUB_LLL: VEC_ARG2(l_dest = l1 - l2);
         case OP_MUL_LLL: VEC_ARG2(l_dest = l1 * l2);
         case OP_DIV_LLL: VEC_ARG2(l_dest = l2 ? (l1 / l2) : 0);
-#if _MSC_VER <= 1500
-        case OP_POW_LLL: VEC_ARG2(l_dest = (l2 < 0) ? (1 / l1) : (long long)pow((long double)l1, (long double)l2));
-#else
         case OP_POW_LLL: VEC_ARG2(l_dest = (l2 < 0) ? (1 / l1) : (long long)llround(pow((long double)l1, (long double)l2)));
-#endif
         case OP_MOD_LLL: VEC_ARG2(l_dest = l2 ? (l1 % l2) : 0);
         case OP_LSHIFT_LLL: VEC_ARG2(l_dest = l1 << l2);
         case OP_RSHIFT_LLL: VEC_ARG2(l_dest = l1 >> l2);

--- a/numexpr/interpreter.cpp
+++ b/numexpr/interpreter.cpp
@@ -9,7 +9,7 @@
 
 #include "module.hpp"
 #include <numpy/npy_cpu.h>
-#include <cmath>
+#include <math.h>
 #include <string.h>
 #include <assert.h>
 #include <vector>

--- a/numexpr/interpreter.cpp
+++ b/numexpr/interpreter.cpp
@@ -9,7 +9,7 @@
 
 #include "module.hpp"
 #include <numpy/npy_cpu.h>
-#include <math.h>
+#include <cmath>
 #include <string.h>
 #include <assert.h>
 #include <vector>


### PR DESCRIPTION
Simply casting does not guarantee what might be considered a default
mathematical behaviour, since it might return non-expected results
(ie by truncating).
Apply llround to the pow result. That way, the result will be rounded
to the closest integer value after the long double operation.

Signed-off-by: Fernando Seiti Furusato <ferseiti@linux.vnet.ibm.com>