### PR TITLE
Support ceil() and floor() functions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -190,6 +190,10 @@ Supported functions are listed below::
       Complex from real and imaginary parts.
   * contains(str, str): bool
       Returns True for every string in `op1` that contains `op2`.
+  * ceil(float|double): float|double
+      Round up towards positive infinity to the closest integer.
+  * floor(float|double): float|double
+      Round down towards negative infinity to the closest integer.
 
 .. Notes:
 

--- a/numexpr/expressions.py
+++ b/numexpr/expressions.py
@@ -371,6 +371,8 @@ functions = {
     'expm1': func(numpy.expm1, 'float'),
 
     'abs': func(numpy.absolute, 'float'),
+    'ceil': func(numpy.ceil, 'float', 'double'),
+    'floor': func(numpy.floor, 'float', 'double'),
 
     'where': where_func,
 

--- a/numexpr/functions.hpp
+++ b/numexpr/functions.hpp
@@ -34,6 +34,8 @@ FUNC_FF(FUNC_EXP_FF,     "exp_ff",      expf,   expf2,   vsExp)
 FUNC_FF(FUNC_EXPM1_FF,   "expm1_ff",    expm1f, expm1f2, vsExpm1)
 FUNC_FF(FUNC_ABS_FF,     "absolute_ff", fabsf,  fabsf2,  vsAbs)
 FUNC_FF(FUNC_CONJ_FF,    "conjugate_ff",fconjf, fconjf2, vsConj)
+FUNC_FF(FUNC_CEIL_FF,    "ceil_ff",     ceilf,  ceilf2,  NULL)
+FUNC_FF(FUNC_FLOOR_FF,   "floor_ff",    floorf, floorf2, NULL)
 FUNC_FF(FUNC_FF_LAST,    NULL,          NULL,   NULL,    NULL)
 #ifdef ELIDE_FUNC_FF
 #undef ELIDE_FUNC_FF
@@ -76,6 +78,8 @@ FUNC_DD(FUNC_EXP_DD,     "exp_dd",      exp,   vdExp)
 FUNC_DD(FUNC_EXPM1_DD,   "expm1_dd",    expm1, vdExpm1)
 FUNC_DD(FUNC_ABS_DD,     "absolute_dd", fabs,  vdAbs)
 FUNC_DD(FUNC_CONJ_DD,    "conjugate_dd",fconj, vdConj)
+FUNC_DD(FUNC_CEIL_DD,    "ceil_dd",     ceil,  NULL)
+FUNC_DD(FUNC_FLOOR_DD,   "floor_dd",    floor, NULL)
 FUNC_DD(FUNC_DD_LAST,    NULL,          NULL,  NULL)
 #ifdef ELIDE_FUNC_DD
 #undef ELIDE_FUNC_DD

--- a/numexpr/msvc_function_stubs.hpp
+++ b/numexpr/msvc_function_stubs.hpp
@@ -38,6 +38,7 @@
 #define fabsf(x)    ((float)fabs((double)(x)))
 #define fmodf(x, y)    ((float)fmod((double)(x), (double)(y)))
 #define atan2f(x, y)    ((float)atan2((double)(x), (double)(y)))
+#define ceilf(x)    ((float)ceil((double)(x)))
 
 /* The next are directly called from interp_body.cpp */
 #define powf(x, y)    ((float)pow((double)(x), (double)(y)))
@@ -136,6 +137,14 @@ inline float atan2f2(float x, float y) {
 // conjugate operations
 inline float fconjf2(float x) {
     return x;
+}
+
+inline float ceilf2(float x) {
+    return ceilf(x);
+}
+
+inline float floorf2(float x) {
+    return floorf(x);
 }
 
 #endif // NUMEXPR_MSVC_FUNCTION_STUBS_HPP

--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -516,7 +516,8 @@ func1tests = []
 for func in ['copy', 'ones_like', 'sqrt',
              'sin', 'cos', 'tan', 'arcsin', 'arccos', 'arctan',
              'sinh', 'cosh', 'tanh', 'arcsinh', 'arccosh', 'arctanh',
-             'log', 'log1p', 'log10', 'exp', 'expm1', 'abs', 'conj']:
+             'log', 'log1p', 'log10', 'exp', 'expm1', 'abs', 'conj',
+             'ceil', 'floor']:
     func1tests.append("a + %s(b+c)" % func)
 tests.append(('1_ARG_FUNCS', func1tests))
 


### PR DESCRIPTION
This pull request adds support for the `ceil()` and `floor()` functions which is partially mentioned in #89. E.g.,

```python
>>> import numpy as np, numexpr as ne
>>> A = np.array([0.5])
>>> ne.evaluate("ceil(A)")
array([ 1.])
>>> ne.evaluate("floor(A)")
array([ 0.])
>>> ne.evaluate("ceil(0.5)")
array(1.0)
>>> ne.evaluate("floor(0.5")
array(0.0)
```

I added the `numpy.ceil()` and `numpy.floor()` functions to the `functions` dictionary in *numexpr/expressions.py*. I also added `ceil_dd`, `ceil_ff`, `floor_dd`, and `floor_ff` using the `ceil()`, `ceilf()`, `floor()`, and `floorf()` functions to *numexpr/functions.hpp*. I believe these functions are all part of the C standard and are supported by glibc ([ceil](http://www.gnu.org/software/libc/manual/html_node/Rounding-Functions.html#index-ceil), [floor](http://www.gnu.org/software/libc/manual/html_node/Rounding-Functions.html#index-floor)), MSVC ([ceil](https://msdn.microsoft.com/en-us/library/atdhw2dx.aspx), [floor](https://msdn.microsoft.com/en-us/library/x39715t6.aspx)), and POSIX ([ceil](http://pubs.opengroup.org/onlinepubs/9699919799/functions/ceil.html), [floor](http://pubs.opengroup.org/onlinepubs/9699919799/functions/floor.html)).

I have a few questions.

1. In *numexpr/functions.hpp*, is it alright if the 5th argument to the `FUNC_FF` macro is `NULL` and the 4th argument to the `FUNC_DD` macro is `NULL` for the ceil and floor functions? None of the other macros use `NULL` for that argument and I don't know what the consequences of that would be.

2. Did I place these functions in the appropriate order? The only organization that I noticed was that like functions are grouped together.

3. What exactly needs to be done test-wise? I added `'ceil'` and `'floor'` to the `func1tests` list in *numexpr/tests/test_numexpr.py*, and ran it. It complained about the functions not being implemented for complex numbers. E.g.,

    ```
    'a + ceil(b+c)' not implemented for complex (scalar=0, opt=aggressive)
    ```

    I also received multiple failures about an error not being raised. E.g.,

    ```
    =====================================================================
    FAIL: test_scalar0_float32_aggressive_1_ARG_FUNCS_1134 (__main__.TestExpressions)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "test_numexpr.py", line 1039, in method
        return func()
      File "test_numexpr.py", line 612, in method
        assert np_exception is None, msg
    AssertionError: expected numexpr error not raised for expression 'a + ceil(b+c)' 
    ```

    See [test-results.txt](https://github.com/pydata/numexpr/files/752636/test-results.txt) for the whole output.
