### PR TITLE
Add Python3 classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,8 @@ def setup_package():
                       license='BSD',
                       packages=['numexpr3'],
                       install_requires=requirements,
-                      setup_requires=requirements
+                      setup_requires=requirements,
+                      classifiers=['Programming Language :: Python :: 3'],
     )
     if (len(sys.argv) >= 2 and ('--help' in sys.argv[1:] or sys.argv[1]
     in ('--help-commands', 'egg_info', '--version', 'clean'))):


### PR DESCRIPTION
Motivated by caniusepython3[0] reporting that numexpr doesn't support Python3.

```shell
$ caniusepython3 --projects numexpr
Finding and checking dependencies ...

You need 1 project to transition to Python 3.
Of that 1 project, 1 has no direct dependencies blocking its transition:

  numexpr
```

0: https://pypi.python.org/pypi/caniusepython3