### PR TITLE
Fix segaults with VML; Use VML functions for ceil and floor

### DIFF
--- a/numexpr/functions.hpp
+++ b/numexpr/functions.hpp
@@ -34,8 +34,8 @@ FUNC_FF(FUNC_EXP_FF,     "exp_ff",      expf,   expf2,   vsExp)
 FUNC_FF(FUNC_EXPM1_FF,   "expm1_ff",    expm1f, expm1f2, vsExpm1)
 FUNC_FF(FUNC_ABS_FF,     "absolute_ff", fabsf,  fabsf2,  vsAbs)
 FUNC_FF(FUNC_CONJ_FF,    "conjugate_ff",fconjf, fconjf2, vsConj)
-FUNC_FF(FUNC_CEIL_FF,    "ceil_ff",     ceilf,  ceilf2,  NULL)
-FUNC_FF(FUNC_FLOOR_FF,   "floor_ff",    floorf, floorf2, NULL)
+FUNC_FF(FUNC_CEIL_FF,    "ceil_ff",     ceilf,  ceilf2,  vsCeil)
+FUNC_FF(FUNC_FLOOR_FF,   "floor_ff",    floorf, floorf2, vsFloor)
 FUNC_FF(FUNC_FF_LAST,    NULL,          NULL,   NULL,    NULL)
 #ifdef ELIDE_FUNC_FF
 #undef ELIDE_FUNC_FF
@@ -78,8 +78,8 @@ FUNC_DD(FUNC_EXP_DD,     "exp_dd",      exp,   vdExp)
 FUNC_DD(FUNC_EXPM1_DD,   "expm1_dd",    expm1, vdExpm1)
 FUNC_DD(FUNC_ABS_DD,     "absolute_dd", fabs,  vdAbs)
 FUNC_DD(FUNC_CONJ_DD,    "conjugate_dd",fconj, vdConj)
-FUNC_DD(FUNC_CEIL_DD,    "ceil_dd",     ceil,  NULL)
-FUNC_DD(FUNC_FLOOR_DD,   "floor_dd",    floor, NULL)
+FUNC_DD(FUNC_CEIL_DD,    "ceil_dd",     ceil,  vdCeil)
+FUNC_DD(FUNC_FLOOR_DD,   "floor_dd",    floor, vdFloor)
 FUNC_DD(FUNC_DD_LAST,    NULL,          NULL,  NULL)
 #ifdef ELIDE_FUNC_DD
 #undef ELIDE_FUNC_DD

--- a/numexpr/necompiler.py
+++ b/numexpr/necompiler.py
@@ -63,6 +63,8 @@ vml_functions = [
     "conjugate",
     "arctan2",
     "fmod",
+    "ceil",
+    "floor"
     ]
 
 # Final addtions for Python 3 (mainly for PyTables needs)


### PR DESCRIPTION
Fixes the following segfault(s) during tests:
```
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
Numexpr version:   2.6.3
NumPy version:     1.13.1
Python version:    3.6.2 (v3.6.2:5fd33b5, Jul  8 2017, 04:57:36) [MSC v.1900 64 bit (AMD64)]
AMD/Intel CPU?     True
VML available?     True
VML/MKL version:   Intel(R) Math Kernel Library Version 2018.0.0 Product Build 20170720 for Intel(R) 64 architecture applications
Number of threads used by default: 8 (out of 12 detected cores)
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
<snip>
test_scalar0_float32_b'aggressive'_b'1_ARG_FUNCS'_1134 (numexpr.tests.test_numexpr.suite.<locals>.TestExpressions) ...
Windows fatal exception: access violation

Current thread 0x00003160 (most recent call first):
  File "X:\Python36\Lib\site-packages\numexpr\necompiler.py", line 820 in evaluate
  File "X:\Python36\Lib\site-packages\numexpr\tests\test_numexpr.py", line 601 in method
  File "X:\Python36\Lib\site-packages\numexpr\tests\test_numexpr.py", line 1047 in method
  File "X:\Python36\lib\unittest\case.py", line 605 in run
  File "X:\Python36\lib\unittest\case.py", line 653 in __call__
  File "X:\Python36\lib\unittest\suite.py", line 122 in run
  File "X:\Python36\lib\unittest\suite.py", line 84 in __call__
  File "X:\Python36\lib\unittest\suite.py", line 122 in run
  File "X:\Python36\lib\unittest\suite.py", line 84 in __call__
  File "X:\Python36\lib\unittest\runner.py", line 176 in run
  File "X:\Python36\Lib\site-packages\numexpr\tests\test_numexpr.py", line 1029 in test
  File "<string>", line 1 in <module>
```