### PR TITLE
Fixes test bench in Python 3

### DIFF
--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -35,7 +35,8 @@ import unittest
 TestCase = unittest.TestCase
 
 double = np.double
-
+if sys.version_info[0] >= 3:
+    long = int
 
 # Recommended minimum versions
 minimum_numpy_version = "1.6"


### PR DESCRIPTION
The test bench did not run on Python 3 because of the usage of long,
a deprecated type that does not exist in Python 3. This patch creates
the equivament between Python 2's long and Python's 3 (automatically
growing) int. Fixes #296 