### PR TITLE
Allow for spurious wakeup calls from pthread_cond_wait.

### DIFF
--- a/numexpr/module.hpp
+++ b/numexpr/module.hpp
@@ -36,6 +36,7 @@ struct global_state {
     /* Synchronization variables for threadpool state */
     pthread_mutex_t count_mutex;
     int count_threads;
+    int threads_ready;
     pthread_mutex_t count_threads_mutex;
     pthread_cond_t count_threads_cv;
 


### PR DESCRIPTION
This PR avoids a segmentation fault when `pthread_cond_wait` is woken up spuriously. This fixes issue #306 for me.

I'd add tests, but I don't know how to trigger these spurious wakeups reliably.