### PR TITLE
Typo in cpuinfo license

### DIFF
--- a/LICENSES/cpuinfo.txt
+++ b/LICENSES/cpuinfo.txt
@@ -18,7 +18,7 @@ modification, are permitted provided that the following conditions are met:
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 
-HIS SOFTWARE IS PROVIDED BY PEARU PETERSON ''AS IS'' AND ANY EXPRESS
+THIS SOFTWARE IS PROVIDED BY PEARU PETERSON ''AS IS'' AND ANY EXPRESS
 OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 DISCLAIMED. IN NO EVENT SHALL PEARU PETERSON BE LIABLE FOR ANY DIRECT,


### PR DESCRIPTION
Change "HIS SOFTWARE" to "THIS SOFTWARE".

It is unclear to me if you will be able to accept this pull request (legally) but it seems clear that this was Pearu Peterson's intention.