### PR TITLE
Added local_dict to NumExpr constructor call in evaluate.

### DIFF
--- a/numexpr3/ne3compiler.py
+++ b/numexpr3/ne3compiler.py
@@ -299,7 +299,8 @@ def evaluate(expr: str, name: str=None, lib: int=LIB_STD,
             # need to assemble a new NumExpr object
             pass
 
-    neObj = NumExpr(expr, lib=lib, casting=casting, stackDepth=stackDepth+1)
+    neObj = NumExpr(expr, lib=lib, casting=casting, stackDepth=stackDepth+1,
+                    local_dict=local_dict)
     return neObj.run(verify=False)
     # End of ne3.evaluate()
 


### PR DESCRIPTION
I tried to add functions (minimum, maximum) to numexpr2 and found that first, there are no more opcodes available, and second that these functions are already in the 3.0 branch.  So I'm upgrading my project to use 3.0 and this is the only problem I had.

Thank you for this repo - it's awesome.