### PR TITLE
Adding Travis-Ci Supprt for Arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+    - amd64
+    - arm64
 sudo: false
 
 language: python


### PR DESCRIPTION
Travis-CI has added support for ARM64. Added ARM64 job in Travis-CI.