### PR TITLE
Remove Python 3.4 from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ language: python
 
 python:
   - 2.7
-  - 3.4
   - 3.5
   - 3.6
   - 3.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,14 +14,6 @@ environment:
       PYTHON_VERSION: "2.7.13"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.6"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.6"
-      PYTHON_ARCH: "64"
-
     - PYTHON: "C:\\Python38"
       PYTHON_VERSION: "3.8.0"
       PYTHON_ARCH: "32"


### PR DESCRIPTION
Since v2.7.1 removed support for Python 3.4.