### PR TITLE
Add Getter for VML Thread Count

### DIFF
--- a/numexpr/module.cpp
+++ b/numexpr/module.cpp
@@ -328,6 +328,13 @@ _set_vml_num_threads(PyObject *self, PyObject *args)
     Py_RETURN_NONE;
 }
 
+static PyObject *
+_get_vml_num_threads(PyObject *self, PyObject *args)
+{
+    int max_num_threads = mkl_domain_get_max_threads (MKL_DOMAIN_VML);
+    return Py_BuildValue("i", max_num_threads);
+}
+
 #endif
 
 static PyObject *
@@ -348,6 +355,8 @@ static PyMethodDef module_methods[] = {
      "Set accuracy mode for VML functions."},
     {"_set_vml_num_threads", _set_vml_num_threads, METH_VARARGS,
      "Suggests a maximum number of threads to be used in VML operations."},
+    {"_get_vml_num_threads", _get_vml_num_threads, METH_VARARGS,
+     "Gets the maximum number of threads to be used in VML operations."},
 #endif
     {"_set_num_threads", _set_num_threads, METH_VARARGS,
      "Suggests a maximum number of threads to be used in operations."},

--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -990,6 +990,16 @@ class test_threading_config(TestCase):
         with _environment('OMP_NUM_THREADS', '5'):
             self.assertEquals(5, numexpr._init_num_threads())
 
+    def test_vml_threads_round_trip(self):
+        n_threads = 3
+        if use_vml:
+            numexpr.utils.set_vml_num_threads(n_threads)
+            set_threads = numexpr.utils.get_vml_num_threads()
+            self.assertEquals(n_threads, set_threads)
+        else:
+            self.assertIsNone(numexpr.utils.set_vml_num_threads(n_threads))
+            self.assertIsNone(numexpr.utils.get_vml_num_threads())
+
 
 # Case test for threads
 class test_threading(TestCase):

--- a/numexpr/utils.py
+++ b/numexpr/utils.py
@@ -20,7 +20,8 @@ from numexpr import use_vml
 
 if use_vml:
     from numexpr.interpreter import (
-        _get_vml_version, _set_vml_accuracy_mode, _set_vml_num_threads)
+        _get_vml_version, _set_vml_accuracy_mode, _set_vml_num_threads,
+        _get_vml_num_threads)
 
 
 def get_vml_version():
@@ -76,6 +77,21 @@ def set_vml_num_threads(nthreads):
     """
     if use_vml:
         _set_vml_num_threads(nthreads)
+
+def get_vml_num_threads():
+    """
+    Gets the maximum number of threads to be used in VML operations.
+
+    This function is equivalent to the call
+    `mkl_domain_get_max_threads (MKL_DOMAIN_VML)` in the MKL
+    library.  See:
+
+    http://software.intel.com/en-us/node/522118
+
+    for more info about it.
+    """
+    if use_vml:
+        return _get_vml_num_threads()
 
 
 def set_num_threads(nthreads):


### PR DESCRIPTION
Adds `get_vml_num_threads` to match `set_vml_num_threads`

It's nice to be able to inspect as well as set these values, especially since some libraries seem to be changing these under the hood (per: https://github.com/PyTables/PyTables/issues/786).