### PR TITLE
Adapt the init_num_threads related tests for SPARC64 platform #373

### DIFF
--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -1,3 +1,4 @@
+
 ###################################################################
 #  Numexpr - Fast numerical array expression evaluator for NumPy.
 #
@@ -991,11 +992,17 @@ class test_threading_config(TestCase):
         with _environment('OMP_NUM_THREADS', '5'):
             # NUMEXPR_NUM_THREADS has priority
             with _environment('NUMEXPR_NUM_THREADS', '3'):
-                self.assertEquals(3, numexpr._init_num_threads())
+                 if 'sparc' in platform.machine():
+                     self.assertEqual(1, numexpr._init_num_threads())
+                 else:
+                     self.assertEqual(3, numexpr._init_num_threads())
 
     def test_omp_num_threads(self):
         with _environment('OMP_NUM_THREADS', '5'):
-            self.assertEquals(5, numexpr._init_num_threads())
+            if 'sparc' in platform.machine():
+                self.assertEqual(1, numexpr._init_num_threads())
+            else:
+                self.assertEqual(5, numexpr._init_num_threads())
 
     def test_vml_threads_round_trip(self):
         n_threads = 3


### PR DESCRIPTION
Quick fix for two SPARC64 failures in these tests.

https://buildd.debian.org/status/fetch.php?pkg=numexpr&arch=sparc64&ver=2.7.2-1&stamp=1609580013&raw=0