### PR TITLE
no distutils.version

### DIFF
--- a/numexpr/expressions.py
+++ b/numexpr/expressions.py
@@ -17,8 +17,8 @@ import threading
 import numpy
 # numpy's behavoir sometimes changes with versioning, especially in regard as 
 # to when ints are cast to floats.
-from distutils.version import LooseVersion
-_np_version_forbids_neg_powint = LooseVersion(numpy.__version__) >= LooseVersion('1.12.0b1')
+from packaging.version import parse, Version
+_np_version_forbids_neg_powint = parse(numpy.__version__) > Version('1.12.0b1')
 
 # Declare a double type that does not exist in Python space
 double = numpy.double


### PR DESCRIPTION
solves DeprecationWarning
```
/usr/lib/python3.10/site-packages/numexpr/expressions.py:20:
DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12.
Use setuptools or check PEP 632 for potential alternatives
```