### PR TITLE
FIX: do not use deprecated numpy flag

### DIFF
--- a/numexpr/interpreter.cpp
+++ b/numexpr/interpreter.cpp
@@ -1271,7 +1271,11 @@ NumExpr_run(NumExprObject *self, PyObject *args, PyObject *kwds)
             // a = (PyArrayObject *)PyArray_FromArray(operands[0], dtypes[0],
             //                             NPY_ARRAY_ALIGNED|NPY_ARRAY_WRITEBACKIFCOPY);
             a = (PyArrayObject *)PyArray_FromArray(operands[0], dtypes[0],
+#ifdef NPY_ARRAY_WRITEBACKIFCOPY
                                         NPY_ARRAY_ALIGNED|NPY_ARRAY_WRITEBACKIFCOPY);
+#else
+                                        NPY_ARRAY_ALIGNED|NPY_ARRAY_UPDATEIFCOPY);
+#endif
             if (a == NULL) {
                 goto fail;
             }

--- a/numexpr/interpreter.cpp
+++ b/numexpr/interpreter.cpp
@@ -1271,7 +1271,7 @@ NumExpr_run(NumExprObject *self, PyObject *args, PyObject *kwds)
             // a = (PyArrayObject *)PyArray_FromArray(operands[0], dtypes[0],
             //                             NPY_ARRAY_ALIGNED|NPY_ARRAY_WRITEBACKIFCOPY);
             a = (PyArrayObject *)PyArray_FromArray(operands[0], dtypes[0],
-                                        NPY_ARRAY_ALIGNED|NPY_ARRAY_UPDATEIFCOPY);
+                                        NPY_ARRAY_ALIGNED|NPY_ARRAY_WRITEBACKIFCOPY);
             if (a == NULL) {
                 goto fail;
             }


### PR DESCRIPTION
Per
https://numpy.org/doc/stable/reference/c-api/array.html#c.NPY_ARRAY_WRITEBACKIFCOPY
and
https://numpy.org/doc/stable/reference/c-api/array.html#c.NPY_ARRAY_UPDATEIFCOPY
NPY_ARRAY_WRITEBACKIFCOPY is preferred.
