### PR TITLE
Fix constant dupes

### DIFF
--- a/numexpr/expressions.py
+++ b/numexpr/expressions.py
@@ -142,6 +142,8 @@ def bestConstantType(x):
     # a float (32-bit) array with a double (64-bit) constant.
     if isinstance(x, double):
         return double
+    if isinstance(x, numpy.float32):
+        return float
     if isinstance(x, (int, numpy.integer)):
         # Constants needing more than 32 bits are always
         # considered ``long``, *regardless of the platform*, so we
@@ -504,7 +506,7 @@ class ConstantNode(LeafNode):
     def __init__(self, value=None, children=None):
         kind = getKind(value)
         # Python float constants are double precision by default
-        if kind == 'float':
+        if kind == 'float' and isinstance(value, float):
             kind = 'double'
         LeafNode.__init__(self, value=value, kind=kind)
 

--- a/numexpr/expressions.py
+++ b/numexpr/expressions.py
@@ -156,7 +156,7 @@ def bestConstantType(x):
             y = converter(x)
         except Exception as err:
             continue
-        if y == x:
+        if y == x or numpy.isnan(y):
             return converter
 
 

--- a/numexpr/necompiler.py
+++ b/numexpr/necompiler.py
@@ -342,7 +342,8 @@ def getConstants(ast):
         a = 1 + 3j; b = 5.0
         ne.evaluate('a*2 + 15j - b')
     """
-    constants_order = sorted(ast.allOf('constant'))
+    constant_registers = set([node.reg for node in ast.allOf("constant")]) 
+    constants_order = sorted([r.node for r in constant_registers])
     constants = [convertConstantToKind(a.value, a.astKind)
                  for a in constants_order]
     return constants_order, constants

--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -25,6 +25,7 @@ from numpy import (
     sin, cos, tan, arcsin, arccos, arctan, arctan2,
     sinh, cosh, tanh, arcsinh, arccosh, arctanh,
     log, log1p, log10, exp, expm1, conj)
+import numpy
 from numpy.testing import (assert_equal, assert_array_equal,
                            assert_array_almost_equal, assert_allclose)
 from numpy import shape, allclose, array_equal, ravel, isnan, isinf
@@ -499,6 +500,13 @@ class test_evaluate(TestCase):
         expr = (E.a + _nan)*(E.b + _nan)
         assert_equal(NumExpr(expr, [('a', double), ('b', double)]).constants, (float("nan"),))
 
+
+    def test_f32_constant(self):
+        assert_equal(ConstantNode(numpy.float32(1)).astKind, "float")
+        assert_equal(ConstantNode(numpy.float32("nan")).astKind, "float")
+        assert_equal(ConstantNode(numpy.float32(3)).value.dtype, numpy.dtype("float32"))
+        assert_array_equal(NumExpr(ConstantNode(numpy.float32(1))).run(), 
+                           numpy.array(1, dtype="float32"))
 
     def test_unaligned_singleton(self):
         # Test for issue #397 whether singletons outputs assigned to consts must be 

--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -31,6 +31,7 @@ from numpy import shape, allclose, array_equal, ravel, isnan, isinf
 
 import numexpr
 from numexpr import E, NumExpr, evaluate, re_evaluate, disassemble, use_vml
+from numexpr.expressions import ConstantNode
 
 import unittest
 
@@ -489,6 +490,15 @@ class test_evaluate(TestCase):
 
     def test_constant_deduplication(self):
         assert_equal(NumExpr("(a + 1)*(a - 1)", [('a', np.int32)]).constants, (1,))
+
+    def test_nan_constant(self):
+        assert_equal(str(ConstantNode(float("nan")).value), 'nan')
+
+        # check de-duplication works for nan
+        _nan = ConstantNode(float("nan"))
+        expr = (E.a + _nan)*(E.b + _nan)
+        assert_equal(NumExpr(expr, [('a', double), ('b', double)]).constants, (float("nan"),))
+
 
     def test_unaligned_singleton(self):
         # Test for issue #397 whether singletons outputs assigned to consts must be 

--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -487,6 +487,8 @@ class test_evaluate(TestCase):
             [[b'where_fbff', b'r0', b'r1[m]', b'r2[a]', b'c3[-1.0]'], 
              [b'noop', None, None, None]])
 
+    def test_constant_deduplication(self):
+        assert_equal(NumExpr("(a + 1)*(a - 1)", [('a', np.int32)]).constants, (1,))
 
     def test_unaligned_singleton(self):
         # Test for issue #397 whether singletons outputs assigned to consts must be 

--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -481,6 +481,13 @@ class test_evaluate(TestCase):
         else:
             self.fail()
 
+    def test_disassemble(self):
+        assert_equal(disassemble(NumExpr(
+            "where(m, a, -1)", [('m', bool), ('a', float)])),
+            [[b'where_fbff', b'r0', b'r1[m]', b'r2[a]', b'c3[-1.0]'], 
+             [b'noop', None, None, None]])
+
+
     def test_unaligned_singleton(self):
         # Test for issue #397 whether singletons outputs assigned to consts must be 
         # aligned or not.


### PR DESCRIPTION
This pull requested fixes issue with constant duplication (#414).

But there are also some other minor fixes:

- Properly parse `where_xxxx` instructions in disassembler (do not drop 4-th argument)
- Allow `nan` floating point constant construction
- Allow `np.float32(v)` constants (do not promote those to `double`)

Note that one can only use those constants when building expression with python classes directly, parsing `nan` or `float32` out of textual representation is not enabled by this PR.

Closes #414 

