### PR TITLE
Remove _np_version_forbids_neg_powint

### DIFF
--- a/numexpr/expressions.py
+++ b/numexpr/expressions.py
@@ -15,10 +15,6 @@ import sys
 import threading
 
 import numpy
-# NumPy's behavior sometimes changes with versioning, especially in regard as 
-# to when ints are cast to floats.
-from packaging.version import parse, Version
-_np_version_forbids_neg_powint = parse(numpy.__version__) > Version('1.12.0b1')
 
 # Declare a double type that does not exist in Python space
 double = numpy.double
@@ -275,8 +271,7 @@ def rtruediv_op(a, b):
 
 @ophelper
 def pow_op(a, b):
-    if (_np_version_forbids_neg_powint and
-        b.astKind in ('int', 'long') and
+    if (b.astKind in ('int', 'long') and
         a.astKind in ('int', 'long') and
         numpy.any(b.value < 0)):
 

--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -41,10 +41,6 @@ TestCase = unittest.TestCase
 double = np.double
 long = int
 
-# Recommended minimum versions
-from packaging.version import Version
-minimum_numpy_version = Version('1.7.0')
-present_numpy_version = Version(np.__version__)
 
 class test_numexpr(TestCase):
     """Testing with 1 thread"""
@@ -828,14 +824,9 @@ class test_strings(TestCase):
         str_list = [
             b'\0\0\0', b'\0\0foo\0', b'\0\0foo\0b', b'\0\0foo\0b\0',
             b'foo\0', b'foo\0b', b'foo\0b\0', b'foo\0bar\0baz\0\0']
-        min_tobytes_version = Version('1.9.0')
         for s in str_list:
             r = evaluate('s')
-            if present_numpy_version >= min_tobytes_version:
-                self.assertEqual(s, r.tobytes())  # check *all* stored data
-            else:
-                # ndarray.tostring() is deprecated as of NumPy 1.19
-                self.assertEqual(s, r.tostring())  # check *all* stored data
+            self.assertEqual(s, r.tobytes())  # check *all* stored data
 
     def test_compare_copy(self):
         sarr = self.str_array1
@@ -1102,10 +1093,6 @@ def print_versions():
     from numexpr.cpuinfo import cpu
     import platform
 
-    np_version = Version(np.__version__)
-
-    if np_version < minimum_numpy_version:
-        print('*Warning*: NumPy version is lower than recommended: %s < %s' % (np_version, minimum_numpy_version))
     print('-=' * 38)
     print('Numexpr version:   %s' % numexpr.__version__)
     print('NumPy version:     %s' % np.__version__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 numpy >= 1.13.3
-packaging


### PR DESCRIPTION
The numpy requirement is greater than 1.13. 

Numpy 1.12 is quite old at this stage and most have even moved to 1.19 at this stage