### PR TITLE
Block signal delivery to numexpr-spawned threads

### DIFF
--- a/numexpr/win32/pthread.h
+++ b/numexpr/win32/pthread.h
@@ -93,6 +93,25 @@ extern int pthread_create(pthread_t *thread, const void *unused,
 
 extern int win32_pthread_join(pthread_t *thread, void **value_ptr);
 
+/*
+ * The POSIX signal system has a more developed interface than what's in
+ * Windows. We create a no-op shim layer to proivde enough of the API to
+ * pretend to support what's used when creating threads on POSIX systems.
+ */
+typedef int sigset_t;
+enum sigop {
+    SIG_BLOCK,
+    SIG_UNBLOCK,
+    SIG_SETMASK
+};
+
+static inline int sigemptyset(sigset_t *sigs) { return 0; }
+static inline int sigfillset(sigset_t *sigs) { return 0; }
+static inline int sigaddset(sigset_t *sigs, int sig) { return 0; }
+static inline int sigdelset(sigset_t *sigs, int sig) { return 0; }
+static inline int pthread_sigmask(int how, sigset_t *newmask,
+                                  sigset_t *oldmask) { return 0; }
+
 #ifdef __cplusplus
 } // extern "C"
 #endif


### PR DESCRIPTION
Applications that embed python, or use platform-specific python extensions, may use signals in a way that is currently affected by `numexpr` launching threads.

For example, it is not uncommon for an application main loop to block signals when busy, then unblock those signals while waiting for IO. (see the sigmask argument to `ppoll(2)`)

Signals that arrive during `ppoll(2)` will interrupt the system call, and allow the application to handle any consequences of that signal arriving.  Normally (in a single threaded process), on delivery of an externally generated signal such as SIGALRM, SIGCHLD, SIGIO the main loop will be awoken. IF the thread is otherwise busy, then the signal will be maintained as pending, and will be delivered when the application next enters its idle state with `ppoll` again.

`numexpr` creates threads on import. Such threads inherit their signal masks from the thread that creates them, and, because the import will generally happen early in the lifetime of a program, all signals are nominally unblocked in the `numexpr` threads.

Later, if the "main" thread is running with signals blocked when a signal is sent to the process, the kernel will deliver it to another thread in the process if it is not currently blocking that  signal, namely, one of the `numexpr` threads.

This means that by creating threads with open signal masks, `numexpr` is potentially interfering with the normal operation of programs that are otherwise non-threaded.

Instead, we should block all signals before starting numexpr threads, and then restore the signal mask as it was, so the `numexpr` threads do not participate in signal delivery and processing.