### PR TITLE
Fix setup.py to respect numpy's parsing of libraries in site.cfg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,8 +71,10 @@ def parse_site_cfg():
             site['mkl']['include_dirs'].split(os.pathsep))
         lib_dirs.extend(
             site['mkl']['library_dirs'].split(os.pathsep))
+        # numpy's site.cfg splits libraries by comma, but numexpr historically split by os.pathsep.
+        # For compatibility, we split by both.
         libs.extend(
-            site['mkl']['libraries'].split(os.pathsep))
+            site['mkl']['libraries'].replace(os.pathsep, ',').split(','))
         def_macros.append(('USE_VML', None))
         print(f'FOUND MKL IMPORT')
         


### PR DESCRIPTION
numpy parses libraries in site.cfg by [splitting on comma](https://github.com/numpy/numpy/blob/7fc72776b972bfbfdb909e4b15feb0308cf8adba/site.cfg.example#L19C1-L24). We want to maintain compatibility with that, but we've already established `os.pathname` by accident. To minimize breakages, we support both.

Fixes #407