### PR TITLE
Fix syntax error when building with USE_VML

### DIFF
--- a/numexpr/interpreter.cpp
+++ b/numexpr/interpreter.cpp
@@ -991,7 +991,7 @@ NumExpr_run(NumExprObject *self, PyObject *args, PyObject *kwds)
     int reduction_axis = -1;
     npy_intp reduction_size = -1; // For #277 change this 1 -> -1 to be in-line with NumPy 1.8,
 #ifdef USE_VML
-    int ex_uses_vml = 0
+    int ex_uses_vml = 0;
 #endif
     int is_reduction = 0;
     bool reduction_outer_loop = false, need_output_buffering = false, full_reduction = false;


### PR DESCRIPTION
Fixes a compile error when building with MKL/VML:
```
numexpr/interpreter.cpp(996): error C2144: syntax error: 'int' should be preceded by ';'
error: command 'C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Tools\\MSVC\\14.37.32822\\bin\\HostX86\\x64\\cl.exe' failed with exit code 2
```