### PR TITLE
Remove usage of deprecated np.alltrue().

### DIFF
--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -20,7 +20,7 @@ import subprocess
 import numpy as np
 from numpy import (
     array, arange, empty, zeros, int32, int64, uint16, complex_, float64, rec,
-    copy, ones_like, where, alltrue, linspace,
+    copy, ones_like, where, all as alltrue, linspace,
     sum, prod, sqrt, fmod, floor, ceil,
     sin, cos, tan, arcsin, arccos, arctan, arctan2,
     sinh, cosh, tanh, arcsinh, arccosh, arctanh,


### PR DESCRIPTION
np.alltrue is recently deprecated:
https://numpy.org/doc/stable/release/1.25.0-notes.html#deprecations.

I left np.all aliased to alltrue because `all` is also the name of a builtin, and some linters complain if you overwrite a builtin.