### PR TITLE
Fix scientific notation support

### DIFF
--- a/numexpr/necompiler.py
+++ b/numexpr/necompiler.py
@@ -265,7 +265,7 @@ class Immediate(Register):
 
 _flow_pat = r'[\;\[\:]'
 _dunder_pat = r'__[\w]+__'
-_attr_pat = r'\.\b(?!(real|imag|[eE]?[+-]?\d+)\b)'
+_attr_pat = r'\.\b(?!(real|imag|\d*[eE]?[+-]?\d+)\b)'
 _blacklist_re = re.compile(f'{_flow_pat}|{_dunder_pat}|{_attr_pat}')
 
 def stringToExpression(s, types, context, sanitize: bool=True):

--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -568,6 +568,8 @@ class test_evaluate(TestCase):
             evaluate('a*2e-5')
             evaluate('a*2e+5')
             evaluate('a*2E-5')
+            evaluate('a*2.0e5')
+            evaluate('a*2.2e5')
             evaluate('2.+a')
 
             # pass .real and .imag


### PR DESCRIPTION
This PR modifies the sanitize regular expression to access digits after the `.` with scientific notation.

closes #449, related to https://github.com/pydata/numexpr/issues/442#issuecomment-1685097531