### PR TITLE
sanitization: reduce unnecessary rejections

### DIFF
--- a/numexpr/necompiler.py
+++ b/numexpr/necompiler.py
@@ -264,8 +264,8 @@ class Immediate(Register):
 
 
 _flow_pat = r'[\;\[\:]'
-_dunder_pat = r'__[\w]+__'
-_attr_pat = r'\.\b(?!(real|imag|[eE]?[+-]?\d+)\b)'
+_dunder_pat = r'(^|[^\w])__[\w]+__($|[^\w])'
+_attr_pat = r'\.\b(?!(real|imag|\d*[eE]?[+-]?\d+)\b)'
 _blacklist_re = re.compile(f'{_flow_pat}|{_dunder_pat}|{_attr_pat}')
 
 def stringToExpression(s, types, context, sanitize: bool=True):


### PR DESCRIPTION
Don't reject double underscores that are not at the start or end of a variable name ([pandas uses those](https://ci.debian.net/data/autopkgtest/testing/amd64/p/pandas/38088122/log.gz)), or [scientific-notation numbers with digits after the decimal point](https://ci.debian.net/data/autopkgtest/testing/arm64/p/pyfai/38080705/log.gz).