### PR TITLE
fix sanitizer forbid usage of \d+.\d*j

### DIFF
--- a/numexpr/necompiler.py
+++ b/numexpr/necompiler.py
@@ -265,7 +265,7 @@ class Immediate(Register):
 
 _flow_pat = r'[\;\[\:]'
 _dunder_pat = r'(^|[^\w])__[\w]+__($|[^\w])'
-_attr_pat = r'\.\b(?!(real|imag|\d*[eE]?[+-]?\d+)\b)'
+_attr_pat = r'\.\b(?!(real|imag|(\d*[eE]?[+-]?\d+)|\d*j)\b)'
 _blacklist_re = re.compile(f'{_flow_pat}|{_dunder_pat}|{_attr_pat}')
 
 def stringToExpression(s, types, context, sanitize: bool=True):
@@ -275,6 +275,7 @@ def stringToExpression(s, types, context, sanitize: bool=True):
     # parse into its homebrew AST. This is to protect the call to `eval` below.
     # We forbid `;`, `:`. `[` and `__`, and attribute access via '.'.
     # We cannot ban `.real` or `.imag` however...
+    # We also cannot ban `.\d*j`, where `\d*` is some digits (or none), e.g. 1.5j, 1.j
     if sanitize:
         no_whitespace = re.sub(r'\s+', '', s)
         if _blacklist_re.search(no_whitespace) is not None:


### PR DESCRIPTION
Commit https://github.com/pydata/numexpr/commit/397cc98359301d0e7b96aaa6d3c79419d1d4f189 introduces sanitizer to input string, but it will forbid the usage of imaginary unit `j` like this:

```python
import numexpr as ne
ne.evaluate('1.5j')
```

So I slightly changed the regular expression to allow this usage.

This should fix issue https://github.com/pydata/numexpr/issues/459