### PR TITLE
add NE_MAXARGS for future numpy change NPY_MAXARGS

### DIFF
--- a/numexpr/interpreter.cpp
+++ b/numexpr/interpreter.cpp
@@ -980,10 +980,10 @@ run_interpreter_const(NumExprObject *self, char *output, int *pc_error)
 PyObject *
 NumExpr_run(NumExprObject *self, PyObject *args, PyObject *kwds)
 {
-    PyArrayObject *operands[NPY_MAXARGS];
-    PyArray_Descr *dtypes[NPY_MAXARGS], **dtypes_tmp;
+    PyArrayObject *operands[NE_MAXARGS];
+    PyArray_Descr *dtypes[NE_MAXARGS], **dtypes_tmp;
     PyObject *tmp, *ret;
-    npy_uint32 op_flags[NPY_MAXARGS];
+    npy_uint32 op_flags[NE_MAXARGS];
     NPY_CASTING casting = NPY_SAFE_CASTING;
     NPY_ORDER order = NPY_KEEPORDER;
     unsigned int i, n_inputs;
@@ -997,8 +997,8 @@ NumExpr_run(NumExprObject *self, PyObject *args, PyObject *kwds)
     bool reduction_outer_loop = false, need_output_buffering = false, full_reduction = false;
 
     // To specify axes when doing a reduction
-    int op_axes_values[NPY_MAXARGS][NPY_MAXDIMS],
-         op_axes_reduction_values[NPY_MAXARGS];
+    int op_axes_values[NE_MAXARGS][NPY_MAXDIMS],
+         op_axes_reduction_values[NE_MAXARGS];
     int *op_axes_ptrs[NPY_MAXDIMS];
     int oa_ndim = 0;
     int **op_axes = NULL;

--- a/numexpr/numexpr_config.hpp
+++ b/numexpr/numexpr_config.hpp
@@ -23,6 +23,10 @@
 // environment variable, "NUMEXPR_MAX_THREADS"
 #define DEFAULT_MAX_THREADS 64
 
+// Remove dependence on NPY_MAXARGS, which would be a runtime constant instead of compiletime
+// constant. If numpy raises NPY_MAXARGS, we should notice and raise this as well
+#define NE_MAXARGS 64
+
 #if defined(_WIN32)
   #include "win32/pthread.h"
   #include <process.h>


### PR DESCRIPTION
According to issue  https://github.com/pydata/numexpr/issues/460 NPY_MAXARGS will become a runtime constant so not suitable for stack array size, but should be kept for runtime check.

So I added NE_MAXARGS and currently it's 64 which is enough and if numpy raise NPY_MAXARGS in the future we should notice this and raise it accordingly.