### PR TITLE
fix: under pypy, when no dict args given, kwds is non-null

### DIFF
--- a/numexpr/interpreter.cpp
+++ b/numexpr/interpreter.cpp
@@ -1029,7 +1029,7 @@ NumExpr_run(NumExprObject *self, PyObject *args, PyObject *kwds)
     memset(operands, 0, sizeof(operands));
     memset(dtypes, 0, sizeof(dtypes));
 
-    if (kwds) {
+    if (kwds && PyDict_Size(kwds) > 0) {
         tmp = PyDict_GetItemString(kwds, "casting"); // borrowed ref
         if (tmp != NULL && !PyArray_CastingConverter(tmp, &casting)) {
             return NULL;


### PR DESCRIPTION
Not clearly whether it's bug on `numexpr` side or `pypy` side, but when using `pypy`, sometimes function `Numexpr_Run(PyObject *self, PyObject *args, PyObject *kwds)` gets no dictionary arguments but pointer `kwds` is still non-null. 

So add a further check of the size of dictionary `kwds`. It won't affect the performance since it's only one-time check.

This should fix issue https://github.com/pydata/numexpr/issues/463, although not all errors could be eliminated for `pypy` because `sys` module in `pypy` seems not to have attribute `getrefcount` which is used when testing.