### PR TITLE
fix sanitizer forbid colon within quotes

### DIFF
--- a/numexpr/necompiler.py
+++ b/numexpr/necompiler.py
@@ -278,7 +278,8 @@ def stringToExpression(s, types, context, sanitize: bool=True):
     # We also cannot ban `.\d*j`, where `\d*` is some digits (or none), e.g. 1.5j, 1.j
     if sanitize:
         no_whitespace = re.sub(r'\s+', '', s)
-        if _blacklist_re.search(no_whitespace) is not None:
+        skip_quotes = re.sub(r'(\'[^\']*\')', '', no_whitespace)
+        if _blacklist_re.search(skip_quotes) is not None:
             raise ValueError(f'Expression {s} has forbidden control characters.')
     
     old_ctx = expressions._context.get_current_context()

--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -576,6 +576,14 @@ class test_evaluate(TestCase):
             evaluate('c.real')
             evaluate('c.imag')
 
+            # pass imaginary unit j
+            evaluate('1.5j')
+            evaluate('3.j')
+
+            # pass forbidden characters within quotes
+            x = np.array(['a', 'b'], dtype=bytes)
+            evaluate("x == 'b:'")
+
         
     def test_no_sanitize(self):
         try: # Errors on compile() after eval()


### PR DESCRIPTION
Sanitizer will forbid forbidden characters to be used within quotes, which is unnecessary.

I passed this by firstly removing content within quotes and then let regular expression to match the blacked list.

I also added corresponding tests for this and a previous change https://github.com/pydata/numexpr/pull/462

This should fix issue https://github.com/pydata/numexpr/issues/468