### PR TITLE
Skip test requiring sys.getrefcount() on PyPy

### DIFF
--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -307,7 +307,8 @@ class test_numexpr(TestCase):
         res = evaluate('where(a, b, c)')
         assert_array_equal(res, c)
 
-    
+    @unittest.skipIf(hasattr(sys, "pypy_version_info"),
+                     "PyPy does not have sys.getrefcount()")
     def test_refcount(self):
         # Regression test for issue #310
         a = array([1])


### PR DESCRIPTION
PyPy does not provide `sys.getrefcount()` method due to a different GC implementation, so skip the relevant test when running on PyPy.