### PR TITLE
Avoid erroring when OMP_NUM_THREADS is empty string

### DIFF
--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -18,7 +18,6 @@ from contextlib import contextmanager
 import subprocess
 
 import numpy as np
-from numexpr.utils import detect_number_of_cores
 from numpy import (
     array, arange, empty, zeros, int32, int64, uint16, cdouble, float64, rec,
     copy, ones_like, where, all as alltrue, linspace,
@@ -34,6 +33,7 @@ from numpy import shape, allclose, array_equal, ravel, isnan, isinf
 import numexpr
 from numexpr import E, NumExpr, evaluate, re_evaluate, validate, disassemble, use_vml
 from numexpr.expressions import ConstantNode
+from numexpr.utils import detect_number_of_cores
 
 import unittest
 

--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -18,6 +18,7 @@ from contextlib import contextmanager
 import subprocess
 
 import numpy as np
+from numexpr.utils import detect_number_of_cores
 from numpy import (
     array, arange, empty, zeros, int32, int64, uint16, cdouble, float64, rec,
     copy, ones_like, where, all as alltrue, linspace,
@@ -1157,6 +1158,13 @@ class test_threading_config(TestCase):
                 self.assertEqual(1, numexpr._init_num_threads())
             else:
                 self.assertEqual(5, numexpr._init_num_threads())
+
+    def test_omp_num_threads_empty_string(self):
+        with _environment('OMP_NUM_THREADS', ''):
+            if 'sparc' in platform.machine():
+                self.assertEqual(1, numexpr._init_num_threads())
+            else:
+                self.assertEqual(detect_number_of_cores(), numexpr._init_num_threads())
 
     def test_vml_threads_round_trip(self):
         n_threads = 3

--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -1166,6 +1166,13 @@ class test_threading_config(TestCase):
             else:
                 self.assertEqual(detect_number_of_cores(), numexpr._init_num_threads())
 
+    def test_numexpr_max_threads_empty_string(self):
+        with _environment('NUMEXPR_MAX_THREADS', ''):
+            if 'sparc' in platform.machine():
+                self.assertEqual(1, numexpr._init_num_threads())
+            else:
+                self.assertEqual(detect_number_of_cores(), numexpr._init_num_threads())
+
     def test_vml_threads_round_trip(self):
         n_threads = 3
         if use_vml:

--- a/numexpr/utils.py
+++ b/numexpr/utils.py
@@ -134,7 +134,7 @@ def _init_num_threads():
 
     env_configured = False
     n_cores = detect_number_of_cores()
-    if 'NUMEXPR_MAX_THREADS' in os.environ:
+    if 'NUMEXPR_MAX_THREADS' in os.environ and os.environ['NUMEXPR_NUM_THREADS'] != '':
         # The user has configured NumExpr in the expected way, so suppress logs.
         env_configured = True
         n_cores = MAX_THREADS
@@ -150,7 +150,7 @@ def _init_num_threads():
 
     # Now we check for 'NUMEXPR_NUM_THREADS' or 'OMP_NUM_THREADS' to set the 
     # actual number of threads used.
-    if 'NUMEXPR_NUM_THREADS' in os.environ:
+    if 'NUMEXPR_NUM_THREADS' in os.environ and os.environ['NUMEXPR_NUM_THREADS'] != '':
         requested_threads = int(os.environ['NUMEXPR_NUM_THREADS'])
     elif 'OMP_NUM_THREADS' in os.environ and os.environ['OMP_NUM_THREADS'] != '':
         # Empty string is commonly used to unset the variable

--- a/numexpr/utils.py
+++ b/numexpr/utils.py
@@ -152,7 +152,8 @@ def _init_num_threads():
     # actual number of threads used.
     if 'NUMEXPR_NUM_THREADS' in os.environ:
         requested_threads = int(os.environ['NUMEXPR_NUM_THREADS'])
-    elif 'OMP_NUM_THREADS' in os.environ:
+    elif 'OMP_NUM_THREADS' in os.environ and os.environ['OMP_NUM_THREADS'] != '':
+        # Empty string is commonly used to unset the variable
         requested_threads = int(os.environ['OMP_NUM_THREADS'])
     else:
         requested_threads = n_cores

--- a/numexpr/utils.py
+++ b/numexpr/utils.py
@@ -134,7 +134,7 @@ def _init_num_threads():
 
     env_configured = False
     n_cores = detect_number_of_cores()
-    if 'NUMEXPR_MAX_THREADS' in os.environ and os.environ['NUMEXPR_NUM_THREADS'] != '':
+    if 'NUMEXPR_MAX_THREADS' in os.environ and os.environ['NUMEXPR_MAX_THREADS'] != '':
         # The user has configured NumExpr in the expected way, so suppress logs.
         env_configured = True
         n_cores = MAX_THREADS


### PR DESCRIPTION
unsetting the variable like this is not uncommon but this will raise here unfortunately

This circumvents the issue