### PR TITLE
🖌️ Use a vector version badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ NumExpr: Fast numerical expression evaluator for NumPy
         :target: http://numexpr.readthedocs.io/en/latest
 .. |doi| image:: https://zenodo.org/badge/doi/10.5281/zenodo.2483274.svg
         :target:  https://doi.org/10.5281/zenodo.2483274
-.. |version| image:: https://img.shields.io/pypi/v/numexpr.png
+.. |version| image:: https://img.shields.io/pypi/v/numexpr
         :target: https://pypi.python.org/pypi/numexpr
 
 


### PR DESCRIPTION
_Hello everyone,_

A raster PyPI version badge looks blurry at scales different from 100%, so I believe it's worth switching to a vector badge which looks fine at any scale.

Image below shows how a raster badge looks versus a vector one at 170% scale on my machine.

![raster-vs-vector](https://github.com/pydata/numexpr/assets/5607572/133047cd-20bf-4418-8938-4533cfe58802)

_Best regards!_