### PR TITLE
MAINT: Allow building with NumPy 1.x locally

### DIFF
--- a/numexpr/interpreter.cpp
+++ b/numexpr/interpreter.cpp
@@ -47,6 +47,12 @@
 #define AVAILABLE(Haystack, Haystack_Len, J, Needle_Len)   \
   ((Haystack_Len) >= (J) + (Needle_Len))
 
+// To allow building with NumPy<2 locally define the new NumPy macros:
+#if NPY_ABI_VERSION < 0x02000000
+  #define PyDataType_ELSIZE(descr) ((descr)->elsize)
+  #define PyDataType_SET_ELSIZE(descr, size) (descr)->elsize = size
+#endif
+
 #include "str-two-way.hpp"
 
 #ifdef DEBUG


### PR DESCRIPTION
I have build locally without build isolation to test this.

This is picking up on the comments on the PR.  I have not removed the explicit use of target version, although I tend to agree it is probably easier to just remove it, even if it is maybe slightly less explicit (means conda doesn't have to wonder about it).  OTOH, it is nicely explicit.