### PR TITLE
Fix handling of numexpr.cpu in print_versions()

### DIFF
--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -1334,15 +1334,13 @@ def print_versions():
     print('Python version:    %s' % sys.version)
     (sysname, nodename, release, os_version, machine, processor) = platform.uname()
     print('Platform:          %s-%s-%s' % (sys.platform, machine, os_version))
-    try:
-        # cpuinfo doesn't work on OSX well it seems, so protect these outputs
-        # with a try block
-        cpu_info = cpu.info[0]
+    if type(cpu).__name__ != 'CPUInfoBase':
+        cpu_info = cpu.info
+        if isinstance(cpu_info, list):
+            cpu_info = cpu_info[0]
         print('CPU vendor:        %s' % cpu_info.get('VendorIdentifier', ''))
         print('CPU model:         %s' % cpu_info.get('ProcessorNameString', ''))
         print('CPU clock speed:   %s MHz' % cpu_info.get('~MHz',''))
-    except KeyError:
-        pass
     print('VML available?     %s' % use_vml)
     if use_vml:
         print('VML/MKL version:   %s' % numexpr.get_vml_version())


### PR DESCRIPTION
There are a couple of issues in the way `numexpr.cpu.info` is used in `print_versions()`:

1) all the subclasses of `CPUInfoBase` have a class attribute `info`, whereas `CPUInfoBase` does not; this means that, in case there is no CPU implementation for an OS, `self.info` returns a function (because of `CPUInfoBase.__getattr__()`) which is not subscriptable
2) only few subclasses of `CPUInfoBase` (e.g. `LinuxCPUInfo`, `Win32CPUInfo`) implement `info` as list of dicts for each CPU, whereas the rest of the implementations use a dict with attributes

Since `info` seems to be mostly an internal detail, then adapt `print_versions()` to be a little more flexible:
- do not try to query attributes in case the actual CPU implementation is `CPUInfoBase`: it is not implemented for the current OS, so there is nothing to query anyway (fixes (1))
- get the first element of `info` only in case it is a list (fixes (2))
- drop the catch of `KeyError`, which should not happen anymore now