### PR TITLE
WHL: upgrade cibuildwheel, add `cp314` wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,13 +33,13 @@ jobs:
           # Linux x86_64 builds
           - os: ubuntu-latest
             arch: x86_64
-            cibw_pattern: "cp3{10,11,12,13,13t}-manylinux*"
+            cibw_pattern: "*manylinux*"
             artifact_name: "linux-x86_64"
 
           # Linux ARM64 builds (native runners)
           - os: ubuntu-24.04-arm
             arch: aarch64
-            cibw_pattern: "cp3{10,11,12,13,13t}-manylinux*"
+            cibw_pattern: "*manylinux*"
             artifact_name: "linux-aarch64"
             # Don't use native runners for now (looks like wait times are too long)
             #runs-on: ["ubuntu-latest", "arm64"]
@@ -47,13 +47,13 @@ jobs:
           # Windows builds
           - os: windows-latest
             arch: x86_64
-            cibw_pattern: "cp3{10,11,12,13,13t}-win*"
+            cibw_pattern: "*"
             artifact_name: "windows-x86_64"
 
           # macOS builds (universal2)
           - os: macos-latest
             arch: x86_64
-            cibw_pattern: "cp3{10,11,12,13,13t}-macosx*"
+            cibw_pattern: "*"
             artifact_name: "macos-universal2"
     steps:
       - uses: actions/checkout@v3
@@ -72,7 +72,7 @@ jobs:
           echo "CIBW_TEST_COMMAND=pytest --parallel-threads=4 --pyargs numexpr" >> "$GITHUB_ENV"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23
+        uses: pypa/cibuildwheel@v3.1.3
 
       - name: Make sdist
         if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,7 @@ permissions:
   contents: read
 
 env:
-  CIBW_BEFORE_BUILD: pip install setuptools oldest-supported-numpy pytest
-  CIBW_BEFORE_TEST: pip install pytest
   CIBW_BUILD_VERBOSITY: 1
-  CIBW_TEST_COMMAND: pytest --pyargs numexpr
   # Testing on aarch64 takes too long, as it is currently emulated on GitHub Actions
   # Building for musllinux and aarch64 takes way too much time.
   # Moreover, NumPy is not providing musllinux for x86_64 either, so it's not worth it.
@@ -62,14 +59,6 @@ jobs:
         name: Install Python
         with:
           python-version: '3.x'
-
-      - name: Setup free-threading variables
-        if: ${{ endsWith(matrix.cibw_build, 't-*') }}
-        shell: bash -l {0}
-        run: |
-          echo "CIBW_BEFORE_BUILD=pip install setuptools numpy" >> "$GITHUB_ENV"
-          echo "CIBW_BEFORE_TEST=pip install pytest pytest-run-parallel" >> "$GITHUB_ENV"
-          echo "CIBW_TEST_COMMAND=pytest --parallel-threads=4 --pyargs numexpr" >> "$GITHUB_ENV"
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.3

--- a/numexpr/tests/conftest.py
+++ b/numexpr/tests/conftest.py
@@ -10,6 +10,7 @@
 
 import pytest
 
+
 def pytest_configure(config):
     config.addinivalue_line(
         "markers", "thread_unsafe: mark test as unsafe for parallel execution"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 requires-python = ">=3.10"
 # Follow guidelines from https://scientific-python.org/specs/spec-0000/
@@ -44,7 +45,7 @@ documentation = "https://numexpr.readthedocs.io"
 repository = "https://github.com/pydata/numexpr"
 
 [tool.cibuildwheel]
-skip = "cp36-* cp37-* pp37-* cp38-* pp* *-manylinux_i686 *_ppc64le *_s390x"
+skip = ["*-manylinux_i686", "*_ppc64le", "*_s390x"]
 # Let's use a more recent version of the manylinux image for more modern compilers
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,20 @@ homepage = "https://github.com/pydata/numexpr"
 documentation = "https://numexpr.readthedocs.io"
 repository = "https://github.com/pydata/numexpr"
 
+[dependency-groups]
+test = [
+    "pytest>=7.0.0",
+    "pytest-run-parallel>=0.6.0",
+]
+
 [tool.cibuildwheel]
 skip = ["*-manylinux_i686", "*_ppc64le", "*_s390x"]
 # Let's use a more recent version of the manylinux image for more modern compilers
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
+test-groups = ["test"]
+test-command = ["python -m pytest --pyargs numexpr"]
+
+[[tool.cibuildwheel.overrides]]
+select = "cp31*t-*"
+test-command = ["python -m pytest --parallel-threads=4 --pyargs numexpr"]


### PR DESCRIPTION
I made a couple adjustments to `cibuildwheel`'s configuration, following upstream changes.
Notably:
- unsupported python versions don't need to be explicitly skipped; `project.requires-python` is already taken into account
- `pypy` wheels are not enabled by default any more since `cibuildwheel` `3.0.0`, so stop skipping them explicitly


Also note, as a point of detail, that `CIBW_ENABLE=free-threading-cpython` is *still* necessary for `cp313t`, but it *isn't* for `cp314t`.