### PR TITLE
WHL: enable musllinux wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,6 @@ on: [push, pull_request]
 permissions:
   contents: read
 
-env:
-  CIBW_BUILD_VERBOSITY: 1
-
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }} for ${{ matrix.arch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ jobs:
     permissions:
       contents: write
     env:
-      CIBW_BUILD: ${{ matrix.cibw_pattern }}
       CIBW_ARCHS_LINUX: ${{ matrix.arch }}
       CIBW_ARCHS_MACOS: "x86_64 arm64"
       CIBW_ENABLE: cpython-freethreading
@@ -26,25 +25,21 @@ jobs:
           # Linux x86_64 builds
           - os: ubuntu-latest
             arch: x86_64
-            cibw_pattern: "*"
             artifact_name: "linux-x86_64"
 
           # Linux ARM64 builds (native runners)
           - os: ubuntu-24.04-arm
             arch: aarch64
-            cibw_pattern: "*"
             artifact_name: "linux-aarch64"
 
           # Windows builds
           - os: windows-latest
             arch: x86_64
-            cibw_pattern: "*"
             artifact_name: "windows-x86_64"
 
           # macOS builds (universal2)
           - os: macos-latest
             arch: x86_64
-            cibw_pattern: "*"
             artifact_name: "macos-universal2"
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,6 @@ permissions:
 
 env:
   CIBW_BUILD_VERBOSITY: 1
-  # Testing on aarch64 takes too long, as it is currently emulated on GitHub Actions
-  # Building for musllinux and aarch64 takes way too much time.
-  # Moreover, NumPy is not providing musllinux for x86_64 either, so it's not worth it.
-  CIBW_SKIP: "*musllinux*aarch64* *musllinux*x86_64*"
 
 jobs:
   build_wheels:
@@ -30,16 +26,14 @@ jobs:
           # Linux x86_64 builds
           - os: ubuntu-latest
             arch: x86_64
-            cibw_pattern: "*manylinux*"
+            cibw_pattern: "*"
             artifact_name: "linux-x86_64"
 
           # Linux ARM64 builds (native runners)
           - os: ubuntu-24.04-arm
             arch: aarch64
-            cibw_pattern: "*manylinux*"
+            cibw_pattern: "*"
             artifact_name: "linux-aarch64"
-            # Don't use native runners for now (looks like wait times are too long)
-            #runs-on: ["ubuntu-latest", "arm64"]
 
           # Windows builds
           - os: windows-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ test = [
 ]
 
 [tool.cibuildwheel]
+build-verbosity = 1
 skip = ["*-manylinux_i686", "*_ppc64le", "*_s390x"]
 # Let's use a more recent version of the manylinux image for more modern compilers
 manylinux-x86_64-image = "manylinux_2_28"


### PR DESCRIPTION
Based of #517
I noticed at least one reason for not building these wheels was outdated (numpy *does* provide `musllinux-x86_64` as well as `musllinux-aarch64` wheels these days), so I wanted to give it a spin (pun intended)