### PR TITLE
Close comment to avoid compiler warning

### DIFF
--- a/numexpr/numexpr_config.hpp
+++ b/numexpr/numexpr_config.hpp
@@ -48,9 +48,9 @@
   #include "msvc_function_stubs.hpp"
 #else
 /* GCC/Clang version: use std:: (can't use it for windows)
-msvc_function_stubs contains windows alternatives
+   msvc_function_stubs contains windows alternatives */
 /* Due to casting problems (normally return ints not bools, easiest to define
-non-overloaded wrappers for these functions) */
+   non-overloaded wrappers for these functions) */
 inline bool isfinitef_(float x) { return !!::isfinite(x); }
 inline bool isnanf_(float x)    { return !!::isnan(x); }
 inline bool isfinited(double x) { return !!::isfinite(x); }


### PR DESCRIPTION
This appears over and over in the build log:
```
  In file included from numexpr/module.hpp:17,
                   from numexpr/module.cpp:12:
  numexpr/numexpr_config.hpp:52:1: warning: ‘/*’ within comment [-Wcomment]
     52 | /* Due to casting problems (normally return ints not bools, easiest to define
```