### PR TITLE
Add arm64 windows wheel builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
             artifact_name: "windows-x86_64"
             python-version: "3.x"
 
-          # Windows ARM^$ (build wheels)
+          # Windows ARM64 (build wheels)
           - os: windows-11-arm
             arch: aarch64
             artifact_name: "windows-arm64"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,12 @@ jobs:
             artifact_name: "windows-x86_64"
             python-version: "3.x"
 
+          # Windows ARM^$ (build wheels)
+          - os: windows-11-arm
+            arch: aarch64
+            artifact_name: "windows-arm64"
+            python-version: "3.x"
+
           # macOS (build wheels)
           - os: macos-latest
             arch: x86_64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ test = [
 
 [tool.cibuildwheel]
 build-verbosity = 1
-skip = ["*-manylinux_i686", "*_ppc64le", "*_s390x"]
+skip = ["*-manylinux_i686", "*_ppc64le", "*_s390x", "cp310-win_arm64"]
 # Let's use a more recent version of the manylinux image for more modern compilers
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"


### PR DESCRIPTION
Closes #550 

This would add arm64 windows builds to the `build.yml` workflow for 3.11+ (windows arm64 numpy is not available for python<=3.10)