### PR TITLE
Avoid retaining evaluate out arrays

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -6,6 +6,7 @@ Changes from 2.14.1 to 2.14.2
 -----------------------------
 
 * **Under development.**
+* Avoid keeping arrays passed as ``out=`` alive in the ``re_evaluate`` cache.
 
 Changes from 2.14.0 to 2.14.1
 -----------------------------

--- a/numexpr/necompiler.py
+++ b/numexpr/necompiler.py
@@ -795,10 +795,10 @@ _numexpr_last = threading.local()
 evaluate_lock = threading.Lock()
 
 
-def _cache_last_kwargs(out: numpy.ndarray,
+def _cache_last_kwargs(out: Optional[numpy.ndarray],
                        order: str,
                        casting: str,
-                       ex_uses_vml: bool) -> Dict:
+                       ex_uses_vml: bool) -> Dict[str, object]:
     return {
         'out': None if out is None else weakref.ref(out),
         'order': order,

--- a/numexpr/necompiler.py
+++ b/numexpr/necompiler.py
@@ -14,6 +14,7 @@ import os
 import re
 import sys
 import threading
+import weakref
 from typing import Dict, Optional
 
 import numpy
@@ -794,6 +795,26 @@ _numexpr_last = threading.local()
 evaluate_lock = threading.Lock()
 
 
+def _cache_last_kwargs(out: numpy.ndarray,
+                       order: str,
+                       casting: str,
+                       ex_uses_vml: bool) -> Dict:
+    return {
+        'out': None if out is None else weakref.ref(out),
+        'order': order,
+        'casting': casting,
+        'ex_uses_vml': ex_uses_vml,
+    }
+
+
+def _resolve_last_kwargs(kwargs: Dict) -> Dict:
+    kwargs = kwargs.copy()
+    out = kwargs.get('out')
+    if isinstance(out, weakref.ReferenceType):
+        kwargs['out'] = out()
+    return kwargs
+
+
 def validate(ex: str,
              local_dict: Optional[Dict] = None,
              global_dict: Optional[Dict] = None,
@@ -905,8 +926,7 @@ def validate(ex: str,
             compiled_ex = _numexpr_cache.c[numexpr_key]
         except KeyError:
             compiled_ex = _numexpr_cache.c[numexpr_key] = NumExpr(ex, signature, sanitize=sanitize, **context)
-        kwargs = {'out': out, 'order': order, 'casting': casting,
-                  'ex_uses_vml': ex_uses_vml}
+        kwargs = _cache_last_kwargs(out, order, casting, ex_uses_vml)
         _numexpr_last.l.set(ex=compiled_ex, argnames=names, kwargs=kwargs)
     except Exception as e:
         return e
@@ -1049,6 +1069,6 @@ def re_evaluate(local_dict: Optional[Dict] = None,
         raise RuntimeError("A previous evaluate() execution was not found, please call `validate` or `evaluate` once before `re_evaluate`")
     argnames = _numexpr_last.l['argnames']
     args = getArguments(argnames, local_dict, global_dict, _frame_depth=_frame_depth)
-    kwargs = _numexpr_last.l['kwargs']
+    kwargs = _resolve_last_kwargs(_numexpr_last.l['kwargs'])
     # with evaluate_lock:
     return compiled_ex(*args, **kwargs)

--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -9,13 +9,14 @@
 #  rights to use.
 ####################################################################
 
-
+import gc
 import os
 import platform
 import subprocess
 import sys
 import unittest
 import warnings
+import weakref
 from contextlib import contextmanager
 from unittest.mock import MagicMock
 
@@ -411,6 +412,30 @@ class test_evaluate(TestCase):
         x = evaluate("2*a + 3*b*c", local_dict=local_dict)
         x = re_evaluate(local_dict=local_dict)
         assert_array_equal(x, array([86., 124., 168.]))
+
+    def test_evaluate_out_is_not_kept_alive(self):
+        a = arange(1000.0)
+        out = zeros(a.shape)
+        out_ref = weakref.ref(out)
+
+        evaluate("a + 1", local_dict={"a": a}, out=out)
+        del out
+        gc.collect()
+
+        assert out_ref() is None
+
+    def test_re_evaluate_reuses_live_out(self):
+        a = array([1., 2., 3.])
+        out = zeros(a.shape)
+
+        x = evaluate("a + 1", local_dict={"a": a}, out=out)
+        assert x is out
+        assert_array_equal(out, array([2., 3., 4.]))
+
+        a = array([4., 5., 6.])
+        x = re_evaluate(local_dict={"a": a})
+        assert x is out
+        assert_array_equal(out, array([5., 6., 7.]))
 
     def test_validate(self):
         a = array([1., 2., 3.])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ test = [
 
 [tool.cibuildwheel]
 build-verbosity = 1
-skip = ["*-manylinux_i686", "*_ppc64le", "*_s390x", "cp310-win_arm64"]
+skip = ["*-manylinux_i686", "*_ppc64le", "*_s390x", "cp310-win_arm64", "cp313t-*"]
 # Let's use a more recent version of the manylinux image for more modern compilers
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
@@ -60,5 +60,5 @@ test-groups = ["test"]
 test-command = ["python -m pytest --pyargs numexpr"]
 
 [[tool.cibuildwheel.overrides]]
-select = "cp31*t-*"
+select = "cp314t-*"
 test-command = ["python -m pytest --parallel-threads=4 --pyargs numexpr"]


### PR DESCRIPTION
Fixes #558.

`validate()` cached the `out=` array directly in `_numexpr_last` so `re_evaluate()` could reuse it. That kept the most recent output array alive even after the caller deleted their last reference.

This stores a weak reference for cached `out=` instead. `re_evaluate()` resolves it when called, so live output arrays are still reused, but released arrays are no longer pinned by the cache.

Tests:
- `.venv/bin/python -m pytest numexpr/tests/test_numexpr.py -q`
- `.venv/bin/python -m pytest --pyargs numexpr -q`
- `.venv/bin/python -m compileall -q numexpr`
