### PR TITLE
Harden low-level VM bytecode validation and constant sizing

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -14,6 +14,21 @@ Changes from 2.14.2 to 2.14.3
   by the sanitizer raise ``ValueError``; and unknown functions raise
   ``TypeError``. Sanitization can still be explicitly disabled with
   ``sanitize=False`` or ``NUMEXPR_SANITIZE=0``.
+* Hardened low-level VM bytecode validation against mismatched register widths,
+  writes to read-only registers, truncated extended instructions, unsafe string
+  copies, string temporaries, a non-final instruction writing the output buffer
+  of a reduction program, register signatures desynchronised by an embedded NUL
+  byte, and integer overflow while sizing constant storage. Validation now runs
+  *before* the program is installed on the ``NumExpr`` object, and ``run()``
+  refuses to execute an object whose ``__init__`` never completed.
+* ``numexpr.interpreter.NumExpr`` objects are now single-initialisation: calling
+  ``__init__`` again on a built object raises ``RuntimeError`` instead of
+  freeing the register buffers that a concurrent ``run()`` may still be using.
+  A *failed* ``__init__`` installs nothing and can be retried.
+* Fixed the ordering of string comparisons against an empty string: an empty
+  operand now sorts before a non-empty one, so ``a < b''`` and ``a <= b''``
+  agree with NumPy, and two empty operands compare equal without reading
+  uninitialised memory.
 
 Changes from 2.14.1 to 2.14.2
 -----------------------------

--- a/numexpr/interpreter.cpp
+++ b/numexpr/interpreter.cpp
@@ -393,15 +393,20 @@ get_reduction_axis(PyObject* program) {
 
 
 
+/* Validate a program against the register layout it will run on.  This takes
+   the raw pieces rather than a NumExprObject so that NumExpr_init can call it
+   *before* installing anything into the object. */
 int
-check_program(NumExprObject *self)
+check_program(PyObject *program_object, PyObject *fullsig_object,
+              PyObject *signature_object, int n_constants, int n_temps)
 {
     unsigned char *program;
-    Py_ssize_t prog_len, n_buffers, n_inputs;
+    Py_ssize_t prog_len, n_buffers, n_inputs, first_temp, reg;
     int pc, arg, argloc, argno, sig;
     char *fullsig, *signature;
+    bool is_reduction;
 
-    if (PyBytes_AsStringAndSize(self->program, (char **)&program,
+    if (PyBytes_AsStringAndSize(program_object, (char **)&program,
                                 &prog_len) < 0) {
         PyErr_Format(PyExc_RuntimeError, "invalid program: can't read program");
         return -1;
@@ -410,12 +415,16 @@ check_program(NumExprObject *self)
         PyErr_Format(PyExc_RuntimeError, "invalid program: prog_len mod 4 != 0");
         return -1;
     }
-    if (PyBytes_AsStringAndSize(self->fullsig, (char **)&fullsig,
+    if (prog_len == 0) {
+        PyErr_SetString(PyExc_RuntimeError, "invalid program: program is empty");
+        return -1;
+    }
+    if (PyBytes_AsStringAndSize(fullsig_object, (char **)&fullsig,
                                 &n_buffers) < 0) {
         PyErr_Format(PyExc_RuntimeError, "invalid program: can't read fullsig");
         return -1;
     }
-    if (PyBytes_AsStringAndSize(self->signature, (char **)&signature,
+    if (PyBytes_AsStringAndSize(signature_object, (char **)&signature,
                                 &n_inputs) < 0) {
         PyErr_Format(PyExc_RuntimeError, "invalid program: can't read signature");
         return -1;
@@ -424,6 +433,26 @@ check_program(NumExprObject *self)
         PyErr_Format(PyExc_RuntimeError, "invalid program: too many buffers");
         return -1;
     }
+    /* fullsig is built with PyBytes_FromFormat("%c%s%s%s", ...), whose %s stops
+       at the first NUL byte.  An embedded NUL in signature or tempsig would
+       shorten fullsig without shortening mem[]/memsizes[], so every register
+       index past the NUL would then be described by the wrong signature
+       character.  Reject the whole class by checking the layout invariant. */
+    if (n_buffers != 1 + n_inputs + n_constants + n_temps) {
+        PyErr_Format(PyExc_RuntimeError,
+            "invalid program: fullsig describes %i buffers but the register map "
+            "has %i (1 output + %i inputs + %i constants + %i temporaries); "
+            "signature and tempsig must not contain NUL bytes",
+            (int)n_buffers, 1 + (int)n_inputs + n_constants + n_temps,
+            (int)n_inputs, n_constants, n_temps);
+        return -1;
+    }
+    first_temp = 1 + n_inputs + n_constants;
+    /* A reduction program accumulates into the output register, which
+       NumExpr_run allocates as a *single* element for a full reduction.  Only
+       the final reduction instruction may write it -- an ordinary opcode
+       targeting register 0 writes a whole BLOCK_SIZE1 block past its end. */
+    is_reduction = program[prog_len-4] > OP_REDUCTION;
     for (pc = 0; pc < prog_len; pc += 4) {
         unsigned int op = program[pc];
         if (op == OP_NOOP) {
@@ -445,11 +474,13 @@ check_program(NumExprObject *self)
                 argloc = pc+argno+1;
             }
             if (argno >= 3) {
-                if (pc + 1 >= prog_len) {
-                    PyErr_Format(PyExc_RuntimeError, "invalid program: double opcode (%c) at end (%i)", pc, sig);
+                argloc = pc+argno+2;
+                if (argloc >= prog_len) {
+                    PyErr_Format(PyExc_RuntimeError,
+                        "invalid program: truncated double instruction for opcode %u at %i",
+                        op, pc);
                     return -1;
                 }
-                argloc = pc+argno+2;
             }
             arg = program[argloc];
 
@@ -525,16 +556,49 @@ check_program(NumExprObject *self)
                     PyErr_Format(PyExc_RuntimeError, "invalid program: internal checker error processing %i", argloc);
                     return -1;
                 }
-            /* The next is to avoid problems with the ('i','l') duality,
-               specially in 64-bit platforms */
-            } else if (((sig == 'l') && (fullsig[arg] == 'i')) ||
-                       ((sig == 'i') && (fullsig[arg] == 'l'))) {
-              ;
             } else if (sig != fullsig[arg]) {
                 PyErr_Format(PyExc_RuntimeError,
-                "invalid : opcode signature doesn't match buffer (%c vs %c) at %i", sig, fullsig[arg], argloc);
+                "invalid program: opcode signature doesn't match buffer (%c vs %c) at %i", sig, fullsig[arg], argloc);
                 return -1;
             }
+            if (sig != 'n' && argno == 0 && arg != 0 && arg < first_temp) {
+                PyErr_Format(PyExc_RuntimeError,
+                    "invalid program: destination buffer is read-only (%i) at %i",
+                    arg, argloc);
+                return -1;
+            }
+            if (sig != 'n' && argno == 0 && arg == 0 && is_reduction &&
+                    pc != prog_len-4) {
+                PyErr_Format(PyExc_RuntimeError,
+                    "invalid program: only the final reduction instruction may "
+                    "write the output buffer (at %i)", pc);
+                return -1;
+            }
+            if (op == OP_COPY_SS) {
+                if (argno == 0 && arg != 0) {
+                    PyErr_SetString(PyExc_RuntimeError,
+                        "invalid program: copy_ss destination must be the output buffer");
+                    return -1;
+                }
+                if (argno == 1 && arg != 1) {
+                    PyErr_SetString(PyExc_RuntimeError,
+                        "invalid program: copy_ss source must be buffer 1");
+                    return -1;
+                }
+            }
+        }
+    }
+    /* String registers have a zero item size (size_from_char('s') == 0), so a
+       string temporary is a zero-length allocation that the string comparison
+       opcodes would still read from.  No opcode can write one either, since
+       OP_COPY_SS is the only string-producing opcode and its destination is
+       the output buffer. */
+    for (reg = first_temp; reg < n_buffers; reg++) {
+        if (fullsig[reg] == 's') {
+            PyErr_Format(PyExc_RuntimeError,
+                "invalid program: string temporaries are not supported (%i)",
+                (int)reg);
+            return -1;
         }
     }
     return 0;
@@ -576,8 +640,13 @@ stringcmp(const char *s1, const char *s2, npy_intp maxlen1, npy_intp maxlen2)
     // First check if some of the operands is the empty string and if so,
     // just check that the first char of the other is the NULL one.
     // Fixes #121
+    // Two empty operands compare equal without dereferencing either pointer:
+    // a zero-sized register holds no readable byte at all.
+    if (maxlen1 == 0 && maxlen2 == 0) return 0;
     if (maxlen2 == 0) return *s1 != null;
-    if (maxlen1 == 0) return *s2 != null;
+    /* An empty s1 sorts *before* a non-empty s2, so the sign must be negative
+       here -- returning +1 made "a < b''" and "a <= b''" disagree with NumPy. */
+    if (maxlen1 == 0) return -(*s2 != null);
 
     maxlen = (maxlen1 > maxlen2) ? maxlen1 : maxlen2;
     for (nextpos = 1;  nextpos <= maxlen;  nextpos++) {
@@ -1075,6 +1144,13 @@ NumExpr_run(NumExprObject *self, PyObject *args, PyObject *kwds)
 
     // Don't force serial mode by default
     gs.force_serial = 0;
+
+    // A NumExprObject that never completed __init__() (e.g. NumExpr.__new__())
+    // carries an empty program, which last_opcode() would read out of bounds.
+    if (PyBytes_GET_SIZE(self->program) < 4) {
+        PyErr_SetString(PyExc_RuntimeError, "invalid program: program is empty");
+        return NULL;
+    }
 
     // Check whether there's a reduction as the final step
     is_reduction = last_opcode(self->program) > OP_REDUCTION;

--- a/numexpr/interpreter.hpp
+++ b/numexpr/interpreter.hpp
@@ -128,7 +128,8 @@ extern thread_data th_params;
 PyObject *NumExpr_run(NumExprObject *self, PyObject *args, PyObject *kwds);
 
 char get_return_sig(PyObject* program);
-int check_program(NumExprObject *self);
+int check_program(PyObject *program_object, PyObject *fullsig_object,
+                  PyObject *signature_object, int n_constants, int n_temps);
 int get_temps_space(const vm_params& params, char **mem, size_t block_size);
 void free_temps_space(const vm_params& params, char **mem);
 int vm_engine_iter_task(NpyIter *iter, npy_intp *memsteps,

--- a/numexpr/numexpr_object.cpp
+++ b/numexpr/numexpr_object.cpp
@@ -8,6 +8,7 @@
 **********************************************************************/
 
 #include "module.hpp"
+#include <limits.h>
 #include <structmember.h>
 
 #include "numexpr_config.hpp"
@@ -86,25 +87,43 @@ NumExpr_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 static int
 NumExpr_init(NumExprObject *self, PyObject *args, PyObject *kwds)
 {
-    int i, j, mem_offset;
+    int i, j;
     int n_inputs, n_constants, n_temps;
     PyObject *signature = NULL, *tempsig = NULL, *constsig = NULL;
     PyObject *fullsig = NULL, *program = NULL, *constants = NULL;
     PyObject *input_names = NULL, *o_constants = NULL;
-    int *itemsizes = NULL;
+    Py_ssize_t *itemsizes = NULL;
     char **mem = NULL, *rawmem = NULL;
     npy_intp *memsteps;
     npy_intp *memsizes;
+    Py_ssize_t mem_offset, program_size;
     int rawmemsize;
     static char *kwlist[] = {CHARP("signature"), CHARP("tempsig"),
 			     CHARP("program"),  CHARP("constants"),
 			     CHARP("input_names"), NULL};
+
+    /* A NumExpr object is immutable once built (all its members are READONLY),
+       and run() hands self->mem to worker threads while the GIL is released.
+       Re-initialising it would PyMem_Del() those buffers underneath a running
+       interpreter, so only the first successful __init__ is accepted. */
+    if (self->mem != NULL) {
+        PyErr_SetString(PyExc_RuntimeError,
+            "NumExpr objects cannot be re-initialised");
+        return -1;
+    }
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "SSS|OO", kwlist,
                                      &signature,
                                      &tempsig,
                                      &program, &o_constants,
                                      &input_names)) {
+        return -1;
+    }
+
+    program_size = PyBytes_GET_SIZE(program);
+    if (program_size < 4 || program_size % 4 != 0) {
+        PyErr_SetString(PyExc_RuntimeError,
+            "invalid program: expected at least one complete instruction");
         return -1;
     }
 
@@ -123,7 +142,7 @@ NumExpr_init(NumExprObject *self, PyObject *args, PyObject *kwds)
             Py_DECREF(constants);
             return -1;
         }
-        if (!(itemsizes = PyMem_New(int, n_constants))) {
+        if (!(itemsizes = PyMem_New(Py_ssize_t, n_constants))) {
             Py_DECREF(constants);
             Py_DECREF(constsig);
             return -1;
@@ -173,7 +192,7 @@ NumExpr_init(NumExprObject *self, PyObject *args, PyObject *kwds)
             }
             if (PyBytes_Check(o)) {
                 PyBytes_AS_STRING(constsig)[i] = 's';
-                itemsizes[i] = (int)PyBytes_GET_SIZE(o);
+                itemsizes[i] = PyBytes_GET_SIZE(o);
                 continue;
             }
             PyErr_SetString(PyExc_TypeError, "constants must be of type bool/int/long/float/double/complex/bytes");
@@ -209,9 +228,21 @@ NumExpr_init(NumExprObject *self, PyObject *args, PyObject *kwds)
     /* Compute the size of registers. We leave temps out (will be
        malloc'ed later on). */
     rawmemsize = 0;
-    for (i = 0; i < n_constants; i++)
-        rawmemsize += itemsizes[i];
-    rawmemsize *= BLOCK_SIZE1;
+    for (i = 0; i < n_constants; i++) {
+        /* Keep the allocation within the range supported by the old int
+           rawmemsize field, but reject overflow instead of wrapping it. */
+        if (itemsizes[i] > INT_MAX / BLOCK_SIZE1 ||
+            rawmemsize > INT_MAX - itemsizes[i] * BLOCK_SIZE1) {
+            PyErr_SetString(PyExc_OverflowError,
+                "total constant storage is too large");
+            Py_DECREF(constants);
+            Py_DECREF(constsig);
+            Py_DECREF(fullsig);
+            PyMem_Del(itemsizes);
+            return -1;
+        }
+        rawmemsize += (int)(itemsizes[i] * BLOCK_SIZE1);
+    }
 
     mem = PyMem_New(char *, 1 + n_inputs + n_constants + n_temps);
     rawmem = PyMem_New(char, rawmemsize);
@@ -238,7 +269,7 @@ NumExpr_init(NumExprObject *self, PyObject *args, PyObject *kwds)
     mem_offset = 0;
     for (i = 0; i < n_constants; i++) {
         char c = PyBytes_AS_STRING(constsig)[i];
-        int size = itemsizes[i];
+        Py_ssize_t size = itemsizes[i];
         mem[i+n_inputs+1] = rawmem + mem_offset;
         mem_offset += BLOCK_SIZE1 * size;
         memsteps[i+n_inputs+1] = memsizes[i+n_inputs+1] = size;
@@ -286,8 +317,8 @@ NumExpr_init(NumExprObject *self, PyObject *args, PyObject *kwds)
         } else if (c == 's') {
             char *smem = (char*)mem[i+n_inputs+1];
             char *value = PyBytes_AS_STRING(PyTuple_GET_ITEM(constants, i));
-            for (j = 0; j < size*BLOCK_SIZE1; j+=size) {
-                memcpy(smem + j, value, size);
+            for (j = 0; j < BLOCK_SIZE1; j++) {
+                memcpy(smem + j*size, value, size);
             }
         }
     }
@@ -317,6 +348,17 @@ NumExpr_init(NumExprObject *self, PyObject *args, PyObject *kwds)
         return -1;
     }
 
+    /* Validate the program *before* installing it. */
+    if (check_program(program, fullsig, signature, n_constants, n_temps) < 0) {
+        Py_DECREF(constants);
+        Py_DECREF(constsig);
+        Py_DECREF(fullsig);
+        PyMem_Del(mem);
+        PyMem_Del(rawmem);
+        PyMem_Del(memsteps);
+        PyMem_Del(memsizes);
+        return -1;
+    }
 
     #define REPLACE_OBJ(arg) \
     {PyObject *tmp = self->arg; \
@@ -345,7 +387,7 @@ NumExpr_init(NumExprObject *self, PyObject *args, PyObject *kwds)
     #undef INCREF_REPLACE_OBJ
     #undef REPLACE_MEM
 
-    return check_program(self);
+    return 0;
 }
 
 static PyMethodDef NumExpr_methods[] = {

--- a/numexpr/tests/test_numexpr.py
+++ b/numexpr/tests/test_numexpr.py
@@ -378,6 +378,134 @@ class test_numexpr2(test_numexpr):
     nthreads = 2
 
 
+class test_interpreter_validation(TestCase):
+    """Malformed bytecode must be rejected before entering the VM."""
+
+    def test_rejects_integer_width_mismatch(self):
+        program = bytes([
+            50, 2, 1, 1,  # add_lll into an int32 temporary
+            47, 0, 1, 0,  # copy_ll into the output
+        ])
+        with self.assertRaisesRegex(RuntimeError, "signature doesn't match"):
+            numexpr.interpreter.NumExpr(
+                b'l', b'i', program, (), (b'x',)
+            )
+
+    def test_rejects_truncated_double_instruction(self):
+        # where_fbff reads its fourth operand from the following word.
+        program = bytes([77, 0, 1, 2])
+        with self.assertRaisesRegex(RuntimeError, "truncated double instruction"):
+            numexpr.interpreter.NumExpr(
+                b'bff', b'', program, (), (b'a', b'b', b'c')
+            )
+
+    def test_rejects_incomplete_program(self):
+        for program in (b'', b'\0'):
+            with self.assertRaisesRegex(RuntimeError, "complete instruction"):
+                numexpr.interpreter.NumExpr(
+                    b'', b'', program, (), None
+                )
+
+    def test_rejects_copy_ss_from_noncanonical_source(self):
+        program = bytes([116, 0, 2, 0])
+        with self.assertRaisesRegex(RuntimeError, "copy_ss source"):
+            numexpr.interpreter.NumExpr(
+                b'', b'', program, (b'a', b'b' * 16), None
+            )
+
+    def test_rejects_copy_ss_into_temporary(self):
+        program = bytes([
+            116, 2, 1, 0,
+            116, 0, 1, 0,
+        ])
+        with self.assertRaisesRegex(RuntimeError, "copy_ss destination"):
+            numexpr.interpreter.NumExpr(
+                b's', b's', program, (), (b'x',)
+            )
+
+    def test_rejects_store_into_input(self):
+        program = bytes([
+            29, 1, 1, 0,  # copy_ii into read-only input register 1
+            29, 0, 1, 0,
+        ])
+        with self.assertRaisesRegex(RuntimeError, "destination buffer is read-only"):
+            numexpr.interpreter.NumExpr(
+                b'i', b'', program, (), (b'x',)
+            )
+
+    def test_rejects_string_temporary(self):
+        # A 's' temporary has item size 0, so it is a zero-length allocation
+        # that eq_bss would still read from.
+        program = bytes([26, 0, 2, 2])
+        with self.assertRaisesRegex(RuntimeError, "string temporaries"):
+            numexpr.interpreter.NumExpr(
+                b's', b's', program, (), (b'x',)
+            )
+
+    def test_rejects_reinitialisation(self):
+        # Re-initialising would free the register buffers that a concurrent
+        # run() has already handed to the worker threads, and it was also a way
+        # to install a program that never passed validation.
+        valid = bytes([116, 0, 1, 0])
+        nex = numexpr.interpreter.NumExpr(b's', b'', valid, (), (b'x',))
+        for program in (valid, bytes([116, 2, 2, 0])):
+            with self.assertRaisesRegex(RuntimeError, "re-initialised"):
+                nex.__init__(b'bss', b'', program, (), (b'a', b'b', b'c'))
+        self.assertEqual(nex.program, valid)
+        self.assertEqual(nex.signature, b's')
+        x = array([b'abcdefgh'] * 8, dtype='S8')
+        assert_array_equal(nex.run(x), x)
+
+    def test_failed_init_can_be_retried(self):
+        # Nothing is installed by a rejected __init__, so the half-built object
+        # is still usable for a second, valid attempt.
+        nex = numexpr.interpreter.NumExpr.__new__(numexpr.interpreter.NumExpr)
+        with self.assertRaisesRegex(RuntimeError, "read-only"):
+            nex.__init__(b'i', b'', bytes([29, 1, 1, 0, 29, 0, 1, 0]), (), (b'x',))
+        nex.__init__(b'i', b'', bytes([29, 0, 1, 0]), (), (b'x',))
+        x = arange(8, dtype='int32')
+        assert_array_equal(nex.run(x), x)
+
+    def test_rejects_reduction_writing_output_before_the_end(self):
+        # A full reduction allocates a single-element output, so an ordinary
+        # opcode targeting register 0 would write a whole block past its end.
+        program = bytes([
+            88, 0, 1, 1,   # mul_ddd into the output buffer
+            140, 0, 1, 0,  # min_ddn -- makes the output a lone accumulator
+        ])
+        with self.assertRaisesRegex(RuntimeError, "final reduction instruction"):
+            numexpr.interpreter.NumExpr(
+                b'd', b'', program, (), (b'x',)
+            )
+
+    def test_rejects_nul_in_signature(self):
+        # PyBytes_FromFormat("%s") truncates at a NUL, which would desynchronise
+        # fullsig from the register map that mem[]/memsizes[] are indexed with.
+        program = bytes([26, 0, 2, 2])
+        for signature, tempsig in ((b'i\x00', b's'), (b'i\x00i', b'd')):
+            with self.assertRaisesRegex(RuntimeError, "NUL bytes"):
+                numexpr.interpreter.NumExpr(
+                    signature, tempsig, program, (), (b'a', b'b')
+                )
+
+    def test_uninitialized_object_refuses_to_run(self):
+        nex = numexpr.interpreter.NumExpr.__new__(numexpr.interpreter.NumExpr)
+        with self.assertRaisesRegex(RuntimeError, "program is empty"):
+            nex.run()
+
+    def test_rejects_oversized_constant_storage(self):
+        constants = (
+            b'a' * 2_000_000,
+            b'b' * 2_000_000,
+            b'c' * 194_304,
+        )
+        program = bytes([116, 0, 1, 0])
+        with self.assertRaisesRegex(OverflowError, "constant storage"):
+            numexpr.interpreter.NumExpr(
+                b'', b'', program, constants, None
+            )
+
+
 class test_evaluate(TestCase):
     def test_simple(self):
         a = array([1., 2., 3.])
@@ -1288,6 +1416,24 @@ class test_strings(TestCase):
         s1, s2 = b'foo', b'foo\0\0'
         self.assertTrue(evaluate('s1 == s2'))
 
+    def test_compare_empty_string_ordering(self):
+        # An empty operand sorts before every non-empty one; ordering against
+        # an empty constant must agree with NumPy.
+        a = np.array([b'foo', b'', b'bar'])
+        for expr, expected in (
+            ("a < b''", a < b''),
+            ("a <= b''", a <= b''),
+            ("a > b''", a > b''),
+            ("a >= b''", a >= b''),
+            ("a == b''", a == b''),
+            ("a != b''", a != b''),
+            ("b'' < a", b'' < a),
+            ("b'' <= a", b'' <= a),
+        ):
+            assert_array_equal(evaluate(expr), expected, err_msg=expr)
+        self.assertTrue(evaluate("b'' == b''"))
+        self.assertFalse(evaluate("b'' < b''"))
+
 
 # Case for testing selections in fields which are aligned but whose
 # data length is not an exact multiple of the length of the record.
@@ -1639,6 +1785,8 @@ def suite():
         theSuite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(test_numexpr))
         if 'sparc' not in platform.machine():
             theSuite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(test_numexpr2))
+        theSuite.addTest(
+            unittest.defaultTestLoader.loadTestsFromTestCase(test_interpreter_validation))
         theSuite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(test_evaluate))
         # Add the dynamically created TestExpressions to the suite
         if pytest_available:


### PR DESCRIPTION
## Summary

This PR hardens the low-level `interpreter.NumExpr` bytecode boundary so malformed programs are rejected during construction instead of reaching unsafe VM paths.

Validation changes in `check_program()`:

- require exact opcode/register type matches, removing the unsafe int32/int64 interchangeability exception;
- require instruction destinations to be the output or a temporary register, rejecting writes to input and constant registers;
- in a reduction program, allow only the final instruction to write the output register (a full reduction allocates it as a single element);
- enforce the string-copy form emitted by the compiler: output register 0 copied from register 1;
- reject string temporaries, whose item size is 0;
- check that `fullsig` describes exactly `1 + n_inputs + n_constants + n_temps` registers, so an embedded NUL byte cannot desynchronize it from `mem[]`;
- validate the location of operands stored in an extended instruction word before reading them; and
- reject empty or incomplete programs before deriving their return signature.

Lifetime and arithmetic changes:

- validation now runs **before** the program is installed on the object, so a rejected program is never left behind;
- `NumExpr` objects are single-initialization — a second `__init__` on a built object raises instead of freeing register buffers that a concurrent `run()` may still be using. A *failed* `__init__` installs nothing and can be retried;
- `run()` refuses to execute an object whose `__init__` never completed (`NumExpr.__new__(NumExpr)`), which previously read `program[-4]`;
- Use non-truncating string item sizes and checked arithmetic when calculating replicated constant storage.

One behavior fix outside the validator:
- `stringcmp()` no longer dereferences a zero-length operand, and an empty
  operand now sorts *before* a non-empty one, so `a < b''` and `a <= b''` agree
  with NumPy.

The generated bytecode path is unchanged. The stricter checks affect only
malformed or non-canonical programs supplied directly to the low-level
interpreter constructor.

## Why

`check_program()` validated register indexes and most signature characters, but several gaps allowed crafted bytecode to produce width-confused loads/stores, writes into read-only iterator buffers, unchecked string copies, block-sized writes into a single-element reduction accumulator, and an out-of-bounds operand read. 
Separately, constant storage was calculated with 32-bit arithmetic, allowing the allocation size to wrap before constants were copied into it, and the validator ran *after* the program had already been installed on the object, so a rejected program stayed runnable.

The string-copy restriction preserves the invariant already used by output dtype sizing (`interpreter.cpp`, `retsig == 's'` branch): the compiler emits `copy_ss` from register 1 to register 0.



Below Are POCs of the bugs
------------------------------------------------------------------
## Reproducers (before the patch)

All eleven cases below were run against `master` (`7031844`) built with `-fsanitize=address`, CPython 3.12, NumPy 2.5.1, x86-64 Linux. Each is self-contained; `import numpy as np` and `from numexpr import interpreter as I` are assumed.

**1. int32/int64 register-width confusion — heap overflow (write, 4096 bytes)**

```python
numexpr.set_num_threads(1)
prog = bytes([50, 2, 1, 1,      # add_lll -> reg2, which tempsig declares 'i'
              47, 0, 1, 0])     # copy_ll -> output
I.NumExpr(b'l', b'i', prog, (), (b'x',)).run(np.arange(1024, dtype=np.int64))
```
```
ERROR: AddressSanitizer: heap-buffer-overflow ... WRITE of size 8
    #0 vm_engine_iter_task numexpr/interp_body.cpp:284
0x... is located 0 bytes after 4096-byte region
    #1 get_temps_space numexpr/interpreter.cpp:655
```
An `'i'` temporary is `malloc(BLOCK_SIZE1 * 4)`; an `'l'` opcode writes `((long long *)dest)[0..1023]` = 8192 bytes into it.

**2. `OP_COPY_SS` element-size confusion — heap overflow (write, 4096 bytes)**

```python
prog = bytes([116, 0, 2, 0])    # copy_ss r0 <- r2
ne = I.NumExpr(b'', b'', prog, (b'AAAA', b'B' * 4096), None)
ne(out=np.array([b'xxxx'], dtype='S4'), ex_uses_vml=False)
```
```
ERROR: AddressSanitizer: heap-buffer-overflow ... WRITE of size 4096 ... in memcpy
    #2 run_interpreter_const numexpr/interp_body.cpp:209
0x... is located 0 bytes after 4-byte region
```
The output string size is derived from register 1, but the copy source was register 2. Both length and contents can be attacker-controlled.

**3. 32-bit `rawmemsize` overflow — heap overflow (write, 2 MB)**

```python
prog = bytes([116, 0, 1, 0])
I.NumExpr(b'', b'', prog,
          (b'A' * 2000000, b'B' * 2000000, b'C' * 194304), None)
```
```
ERROR: AddressSanitizer: heap-buffer-overflow ... WRITE of size 2000000 ... in memcpy
    #2 NumExpr_init numexpr/numexpr_object.cpp:290
0x... is located 0 bytes after 1-byte region
    #2 NumExpr_init numexpr/numexpr_object.cpp:217
```
The constant sizes sum to 2²², so `sum * BLOCK_SIZE1` wraps to 0 in a 32-bit `int`. The overflow fires at construction, before any `run()`.

**4. Dead bounds check — out-of-bounds read at validation time**

```python
prog = bytes([0, 0, 0, 0]) * 255 + bytes([77, 0, 1, 2])   # where_fbff last
I.NumExpr(b'bff', b'', prog, (), (b'a', b'b', b'c'))
```
```
ERROR: AddressSanitizer: heap-buffer-overflow ... READ of size 1
    #0 check_program numexpr/interpreter.cpp:454
    #1 NumExpr_init numexpr/numexpr_object.cpp:348
0x... is located 0 bytes after 1057-byte region
```
The fourth operand lives at `program[pc+5]`; the guard tested `pc + 1 >= prog_len`, which the loop bounds make permanently false.

**5. Store into a read-only input register — heap overflow (write)**

```python
numexpr.set_num_threads(1)
prog = bytes([116, 2, 2, 0,     # copy_ss -> INPUT reg2
              116, 2, 2, 0,
              116, 0, 2, 0])
I.NumExpr(b'bss', b'', prog, (), (b'a', b'b', b'c')).run(
    np.zeros(2048, dtype=bool),
    np.array([b'abcdefghijklmnop'] * 2048, dtype='S16'),
    np.array([b'abcdefghijklmnop'] * 2048, dtype='S16'))
```
```
ERROR: AddressSanitizer: heap-buffer-overflow ... WRITE of size 16 ... in memcpy
    #2 vm_engine_iter_task numexpr/interp_body.cpp:209
0x... is located 0 bytes after 2048-byte region
```
NumPy sizes the read buffer of an `NPY_ITER_READONLY` operand smaller than the VM block. The same store also reaches `th_worker` (`numexpr/module.cpp`) in the threaded engine.

**6. Reduction output written by a non-final instruction — heap overflow (write)**

```python
numexpr.set_num_threads(1)
prog = bytes([88, 0, 1, 1,      # mul_ddd -> r0
              140, 0, 1, 0])    # min_ddn -> r0 (full reduction)
I.NumExpr(b'd', b'', prog, (), (b'x',)).run(np.arange(2048, dtype=np.float64))
```
```
ERROR: AddressSanitizer: heap-buffer-overflow ... WRITE of size 8
    #0 vm_engine_iter_task numexpr/interp_body.cpp:365
0x... is located 0 bytes after 8-byte region
```
A full reduction allocates the output as one element, but an ordinary opcode targeting register 0 writes a whole `BLOCK_SIZE1` block — up to 8 KiB of attacker-chosen doubles past the end.

**7. Rejected `__init__` still installs its program — every check above bypassed**

```python
numexpr.set_num_threads(1)
nex = I.NumExpr(b's', b'', bytes([116, 0, 1, 0]), (), (b'x',))   # valid
bad = bytes([116, 2, 2, 0, 116, 2, 2, 0, 116, 0, 2, 0])          # case 5
try:
    nex.__init__(b'bss', b'', bad, (), (b'a', b'b', b'c'))
except RuntimeError:
    pass                                    # validation *did* reject it ...
nex.run(np.zeros(2048, dtype=bool),         # ... and it runs anyway
        np.array([b'abcdefghijklmnop'] * 2048, dtype='S16'),
        np.array([b'abcdefghijklmnop'] * 2048, dtype='S16'))
```
Same ASAN report as case 5. `NumExpr_init` installed the program before calling `check_program()`, so raising from `__init__` did not undo the installation.

**8. Concurrent `__init__` during `run()` — heap corruption / use-after-free**

```python
import threading
prog = bytes([86, 0, 1, 1])                 # add_ddd r0 <- r1 + r1
nex = I.NumExpr(b'd', b'', prog, (), (b'x',))
big = np.arange(4_000_000, dtype=np.float64)
stop = []
def reinit():
    while not stop:
        nex.__init__(b'd', b'ddd', prog, (1.0, 2.0, 3.0), (b'x',))
        nex.__init__(b'd', b'', prog, (), (b'x',))
t = threading.Thread(target=reinit); t.start()
for _ in range(200):
    nex.run(big, ex_uses_vml=False)
stop.append(1); t.join()
```
```
ERROR: AddressSanitizer: SEGV on unknown address 0x000000000008 ... T40
    #1 NumExpr_init numexpr/numexpr_object.cpp:219   (in PyMem_Malloc)
```
 `run_interpreter()` captures `params.mem = self->mem` and releases the GIL; `REPLACE_MEM` then `PyMem_Del()`s those buffers underneath the running interpreter. The same race was also observed as `heap-use-after-free READ ... th_worker numexpr/module.cpp` with the free attributed to `NumExpr_init`.

**9. String temporary — read from a zero-length allocation**

```python
numexpr.set_num_threads(1)
nex = I.NumExpr(b's', b's', bytes([26, 0, 2, 2]), (), (b'x',))   # eq_bss on reg2
nex.run(np.array([b'abcdefgh'] * 1024, dtype='S8'))
```
Constructs and runs. `size_from_char('s') == 0`, so the temporary is `malloc(BLOCK_SIZE1 * 0)` and `stringcmp()`'s `if (maxlen2 == 0) return *s1 != null;` dereferences it. Not ASAN-visible on this toolchain (a 1-byte read at a`malloc(0)` pointer is not flagged — confirmed with a standalone C test), but it is out of bounds per the C abstract machine and reads uninitialized memory.
`numexpr_object.cpp` already documents the assumption that "there are no string temporaries"; this makes it true.

**10. Embedded NUL desynchronizes `fullsig` from the register map**

```python
nex = I.NumExpr(b'i\x00i', b'd', bytes([83, 0, 2, 0]), (), (b'a', b'b', b'c'))
print(nex.fullsig)      # b'did'  -- claims r2 is a double
```
Constructs. `fullsig` is built with `PyBytes_FromFormat("%c%s%s%s", ...)`, whose `%s` stops at the first NUL, so every register index past the NUL is described by the wrong signature character — defeating the type and temporaries checks. It is currently unexploitable only by accident (`typecode_from_char('\ 0')` fails later, so `run()` always errors first), i.e., the safety of the validator rested on an unstated invariant.

**11. Ordering against an empty string disagrees with NumPy** (correctness, not
memory safety)

```python
a = np.array([b'foo', b'', b'bar'])
numexpr.evaluate("a < b''")     # [ True False  True]   NumPy: [False False False]
numexpr.evaluate("a <= b''")    # [ True  True  True]   NumPy: [False  True False]
```
`stringcmp()` returned `+1` ("s1 > s2") when `s1` was the empty operand.

After the patch, cases 1–10 are rejected at construction (or, for case 8, at the second `__init__`) and case 11 matches NumPy exactly.




